### PR TITLE
Truly extract the labels

### DIFF
--- a/Kaggle/DigitRecognizer/src/DigitRecognizer.cpp
+++ b/Kaggle/DigitRecognizer/src/DigitRecognizer.cpp
@@ -166,7 +166,7 @@ int main()
   // The original file could be download from
   // https://www.kaggle.com/c/digit-recognizer/data
   data::Load("Kaggle/data/test.csv", tempDataset, true);
-  mat testX = tempDataset.submat(0, 1,
+  mat testX = tempDataset.submat(1, 1,
     tempDataset.n_rows - 1, tempDataset.n_cols - 1);
 
   mat testPredOut;


### PR DESCRIPTION
Since the first column in the data file is the labels, I adjusted the submat index so that one now
truly splits data and labels in different matrices. Before I didn't get any run-time error but the
accuracy on the test sample was of course to low to be credible.