### PR TITLE
Stop forcing OpenMP.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(models C CXX)
 option(FORCE_CXX11
     "Don't check that the compiler supports C++11, just assume it.  Make sure to specify any necessary flag to enable C++11 as part of CXXFLAGS."
     OFF)
+option(USE_OPENMP "If available, use OpenMP for parallelization." OFF)
 
 # If we are not forcing C++11 support, check that the compiler supports C++11
 # and enable it.
@@ -151,7 +152,11 @@ find_package(Boost 1.49
     REQUIRED
 )
 
-find_package(OpenMP)
+if (USE_OPENMP)
+  message(WARNING "Only use OpenMP if mlpack has been compiled with OpenMP.")
+  find_package(OpenMP)
+endif ()
+
 if (OPENMP_FOUND)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")


### PR DESCRIPTION
I added an option for OpenMP instead of always looking for it, in case somebody has OpenMP on their system but haven't compiled mlpack with it.