### PR TITLE
Fixing a minor but epoch comparison warning

### DIFF
--- a/LSTM/TimeSeries-Univariate/src/LSTMTimeSeriesUnivariate.cpp
+++ b/LSTM/TimeSeries-Univariate/src/LSTMTimeSeriesUnivariate.cpp
@@ -264,7 +264,7 @@ int main()
     cout << "Training ..." << endl;
 
     // Run EPOCH number of cycles for optimizing the solution.
-    for (int i = 0; i < EPOCH; i++)
+    for (size_t i = 0; i < EPOCH; i++)
     {
       // Train neural network. If this is the first iteration, weights are
       // random, using current values as starting point otherwise.


### PR DESCRIPTION
In building this repository, I noticed the below warning. So, to be consistent and/or to quiet the warning, let's just use a size_t for the loop iterator to match EPOCH.
```[ 71%] Building CXX object LSTM/TimeSeries-Univariate/CMakeFiles/LSTMTimeSeriesUnivariate.dir/src/LSTMTimeSeriesUnivariate.cpp.o
/home/travis/build/mlpack/models/LSTM/TimeSeries-Univariate/src/LSTMTimeSeriesUnivariate.cpp: In function ‘int main()’:
/home/travis/build/mlpack/models/LSTM/TimeSeries-Univariate/src/LSTMTimeSeriesUnivariate.cpp:267:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (int i = 0; i < EPOCH; i++)```