### PR TITLE
use CMAKE_CXX_STANDARD_REQUIRED for cxx11 check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,13 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 project(models C CXX)
 
 # First, define all the compilation options.
 # We default to debugging mode for developers.
-option(FORCE_CXX11
-    "Don't check that the compiler supports C++11, just assume it.  Make sure to specify any necessary flag to enable C++11 as part of CXXFLAGS."
-    OFF)
 option(DOWNLOAD_ENSMALLEN "If ensmallen is not found, download it." ON)
 option(USE_OPENMP "If available, use OpenMP for parallelization." OFF)
 
-# If we are not forcing C++11 support, check that the compiler supports C++11
-# and enable it.
-if (NOT FORCE_CXX11)
-  include(CMake/CXX11.cmake)
-  check_for_cxx11_compiler(HAS_CXX11)
-
-  if(NOT HAS_CXX11)
-    message(FATAL_ERROR "No C++11 compiler available!")
-  endif()
-  enable_cxx11()
-endif ()
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Include modules in the CMake directory.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake")


### PR DESCRIPTION
closes #46 

It looks this, the method proposed by @rcurtin , [requires cmake 3.1](https://cmake.org/cmake/help/v3.1/variable/CMAKE_CXX_STANDARD_REQUIRED.html) as a minimum.  So this is a PR bumping the version and adding a CXX standard check.
I have no opinion on whether to merge it or close it. What versions of cmake can we consider standard?