### PR TITLE
Adding documentation for dataloader.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing to mlpack/models
+
+mlpack/models is a community-led project; that means that anyone is welcome to
+contribute to mlpack and join the community!  If you would like to make
+improvements to the library, add new features that are useful to you and others,
+or have found a bug that you know how to fix, please submit a pull request!
+
+If you would like to learn more about how to get started contributing, see the
+[Community](http://www.mlpack.org/community.html) page, and if you are
+interested in participating in Google Summer of Code, see
+[mlpack and Google Summer of Code](http://www.mlpack.org/gsoc.html).
+
+## Pull request process
+
+Once a pull request is submitted, it must be approved by at least one member of
+mlpack's Contributors team, to ensure that (if applicable):
+
+ * the design meshes with the rest of mlpack
+ * the style matches the
+   [Style Guide](http://github.com/mlpack/mlpack/wiki/DesignGuidelines)
+ * any new functionality is tested and working
+
+The pull request can be merged as soon as it receives two approvals; 24 hours
+after the first approval, mlpack-bot will provide a second approval.  This is to
+leave time for anyone to comment on the PR before it is merged.
+
+Members of the Contributors team are encouraged to review pull requests that
+have already been reviewed, and pull request contributors are encouraged to seek
+multiple reviews.  Reviews from anyone not on the Contributors team are always
+appreciated and encouraged!
+
+## Reviewing Pull Requests
+
+All mlpack contributors who choose to review and provide feedback on pull
+requests have a responsibility to both the project and the individual making
+the contribution. 
+
+Reviews and feedback should be
+[helpful, insightful, and geared towards improving the contribution](
+  https://www.youtube.com/watch?v=NNXk_WJzyMI).
+If there are reasons why you feel the PR should not be merged, explain
+what those are. Be open to having your mind changed. Be open to
+working with the contributor to make the pull request better.
+
+Please don't leave dismissive or disrespectful reviews!  It's not helpful for
+anyone.
+
+When reviewing a pull request, the primary goals are:
+
+- For the codebase/project to improve
+- For the person submitting the request to succeed
+
+Even if a pull request does not get merged, the submitters should come away
+from the experience feeling like their effort was not wasted or unappreciated.
+Every pull request from a new contributor is an opportunity to grow the community. 
+
+When changes are necessary, request them, do not demand them, and do not assume
+that the contributor already knows how to do that. Be there to lend a helping
+hand in case of need.
+
+Since there can sometimes be a lot more pull requests being opened than
+reviewed, we highly encourage everyone to review each others pull request
+keeping in mind all the above mentioned points.
+
+Let's welcome new contributors with ❤️.
+
+## Pull Request Waiting Time 
+
+models is a community-driven project, so everyone only works on it in their
+free time; this means it may take some time for them to review pull requests.
+While gentle reminders are welcome, please be patient and avoid constantly
+messaging contributors or tagging them on pull requests.
+
+Typically small PRs will be reviewed within a handful of days; larger PRs might
+take a few weeks for an initial review, and it may be a little bit longer in 
+times of high activity.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,16 @@ helping with the transition from the `examples/` repository, be sure to look for
 comments like this one.  Once the transition is done, we can remove this
 comment (and the others).)_
 
-_(If we have functionality to download datasets and also to download
-pretrained model weights, we should put a comment about that here in the main
-description of the repository.)_
+We provide ability to download datasets as well as pretrained weights using our
+utility functions, by default we asume the server to be mlpack.org.
+To dowload any file from mlpack.org simple use following command.
+
+NOTE: Our dataloader and models automatically download weights if neccesary during
+runtime.
+
+```cpp
+Utils::DownloadFile(url, downloadPath);
+```
 
 _(If this repository gets set up as a submodule to the main mlpack repository
 and that is how everything in it should be compiled, then we should point that

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Refer to our wiki page.
 Creating and processing data can be done in just a single line. Don't have the dataset downloaded,
 No worries, we will download and preprocess it for you. Kindly refer to sample code given below.
 
-```
+```cpp
 const string datasetName = "mnist";
 bool shuffleData = true;
 double ratioForTrainTestSplit = 0.75;
@@ -94,12 +94,12 @@ DataLoader<> dataloader(datasetName, shuffleData, ratioForTrainTestSplit);
 ```
 
 To train or test your model with our dataloaders is very simple.
-```
+```cpp
 // Use the dataloader for training.
- model.Train(dataloader.TrainFeatures(), dataloader.TrainLabels());
+model.Train(dataloader.TrainFeatures(), dataloader.TrainLabels());
  
- // Use the dataloader for prediction.
- model.Predict(dataloader.TestFeatures(), dataloader.TestLabels());
+// Use the dataloader for prediction.
+model.Predict(dataloader.TestFeatures(), dataloader.TestLabels());
 ```
 
 Currently supported datasets are mentioned below :
@@ -112,7 +112,7 @@ We are continously adding new datasets to this repository, However you can also
 use our dataloaders to load other datasets. Refer to our dataloaders wiki for more
 information.
 
-```
+```cpp
 DataLoader<> irisDataloader;
 
 const string datasetPath = "mnist";
@@ -141,7 +141,7 @@ apply them to their datasets.
 They can simply be called as follows by calling static functions of ProProcess class i.e.
 PreProcess::SupportedDatasetName
 
-```
+```cpp
 PreProcess<>::MNIST(dataloader.TrainFeatures(), dataloader.TrainLabels(),
     dataloader.ValidFeatures(), dataloader.ValidLabels(), dataloader.TestFeatures());
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ To train or test your model with our dataloaders is very simple.
 ```
 
 Currently supported datasets are mentioned below :
+((I think we should add a table here with various columns and details.))
 ##### 1. MNIST Dataset
 
 #### 2. Loading Other Datasets.
@@ -130,6 +131,23 @@ size_t endInputFeatures = -2;
 irisDataloader(datasetPath, isTrainingData, shuffleData, ratioForTrainTestSplit,
     useFeatureScaling, dropHeader, startInputFeatures, endInputFeatures);
 ```
+
+#### 3. Preprocessing.
+
+For all datasets that we support we provide, We preprocess them internally. We also
+provide access to preprocessor functions for standard datasets incase one needs to
+apply them to their datasets.
+
+They can simply be called as follows by calling static functions of ProProcess class i.e.
+PreProcess::SupportedDatasetName
+
+```
+PreProcess<>::MNIST(dataloader.TrainFeatures(), dataloader.TrainLabels(),
+    dataloader.ValidFeatures(), dataloader.ValidLabels(), dataloader.TestFeatures());
+```
+
+This is especially useful when preprocessing of your dataset resembles any other standard
+dataset that we support.
 
 ### 5. Running Models
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ out here!)_
   1. [Introduction](#1-introduction)
   2. [Dependencies](#2-dependencies)
   3. [Building-From-Source](#3-building-from-source)
-  4. [Running Models](#4-running-models)
+  5. [Running Models](#5-running-models)
   5. [Current Models](#5-current-models)
   6. [Datasets](#6-datasets)
 
@@ -72,11 +72,70 @@ building with 4 cores can be done with the following command:
 
   `make -j4`
 
-### 4. Running Models
+### 4. Using Dataloaders.
+
+This repository provides dataloaders and data preprocessing modules for mlpack library.
+It also provides utility function required required for downloading, extracting and processing
+image, text and sequential data. For more information about dataloaders and utility functions,
+Refer to our wiki page.
+
+#### 1. Dataloaders for popular datasets.
+
+Creating and processing data can be done in just a single line. Don't have the dataset downloaded,
+No worries, we will download and preprocess it for you. Kindly refer to sample code given below.
+
+```
+const string datasetName = "mnist";
+bool shuffleData = true;
+double ratioForTrainTestSplit = 0.75;
+
+// Create the DataLoader object.
+DataLoader<> dataloader(datasetName, shuffleData, ratioForTrainTestSplit);
+```
+
+To train or test your model with our dataloaders is very simple.
+```
+// Use the dataloader for training.
+ model.Train(dataloader.TrainFeatures(), dataloader.TrainLabels());
+ 
+ // Use the dataloader for prediction.
+ model.Predict(dataloader.TestFeatures(), dataloader.TestLabels());
+```
+
+Currently supported datasets are mentioned below :
+##### 1. MNIST Dataset
+
+#### 2. Loading Other Datasets.
+
+We are continously adding new datasets to this repository, However you can also
+use our dataloaders to load other datasets. Refer to our dataloaders wiki for more
+information.
+
+```
+DataLoader<> irisDataloader;
+
+const string datasetPath = "mnist";
+bool shuffleData = true;
+double ratioForTrainTestSplit = 0.75;
+bool isTrainingData = true;
+bool useFeatureScaling = true;
+bool dropHeader = false;
+
+// Starting column index for Training Features.
+size_t startInputFeatures = 0;
+// Ending column index for training Features.
+// We also support wrapped index i.e. -1 implies last column and so on.
+size_t endInputFeatures = -2;
+
+irisDataloader(datasetPath, isTrainingData, shuffleData, ratioForTrainTestSplit,
+    useFeatureScaling, dropHeader, startInputFeatures, endInputFeatures);
+```
+
+### 5. Running Models
 
 _(This section needs significant overhaul once we clean up our build system.)_
 
-### 5. Current Models
+### 6. Current Models
 
 _(This section also needs some cleanup once we know what we're keeping and what
 we're not keeping.)_
@@ -89,7 +148,7 @@ Currently model-zoo project has the following models implemented:
   - Variational Auto-Encoder on MNIST dataset.
   - Variational Convolutional Auto-Encoder on MNIST.
 
-### 6. Datasets
+### 7. Datasets
 
 _(This section will also need to be overhauled, but we should wait until we
 overhaul the sections above too.)_

--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ model.Predict(dataloader.TestFeatures(), dataloader.TestLabels());
 ```
 
 Currently supported datasets are mentioned below :
-((I think we should add a table here with various columns and details.))
-##### 1. MNIST Dataset
+|Dataset| Usage.                           |Details                    |
+|-------|----------------------------------|---------------------------|
+| MNIST |   Dataloader<>&nbsp;("mnist");    | MNIST dataset is the de facto “hello world” dataset of computer vision. Each image is 28 pixels in height and 28 pixels in width, for a total of 784 pixels in total. The training data set, (mnist_train.csv), has 785 columns. The first column, called "label", is the digit that was drawn by the user. The rest of the columns contain the pixel-values of the associated image. |
 
 #### 2. Loading Other Datasets.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ comment (and the others).)_
 
 We provide ability to download datasets as well as pretrained weights using our
 utility functions, by default we asume the server to be mlpack.org.
-To dowload any file from mlpack.org simple use following command.
+To dowload any file from mlpack.org simple use the following command.
 
 NOTE: Our dataloader and models automatically download weights if neccesary during
 runtime.
@@ -28,9 +28,10 @@ out here!)_
   1. [Introduction](#1-introduction)
   2. [Dependencies](#2-dependencies)
   3. [Building-From-Source](#3-building-from-source)
+  4. [Using Dataloaders](#4-using-dataloaders)
   5. [Running Models](#5-running-models)
-  5. [Current Models](#5-current-models)
-  6. [Datasets](#6-datasets)
+  6. [Current Models](#6-current-models)
+  7. [Datasets](#7-datasets)
 
 ###  1. Introduction
 
@@ -79,7 +80,7 @@ building with 4 cores can be done with the following command:
 
   `make -j4`
 
-### 4. Using Dataloaders.
+### 4. Using Dataloaders
 
 This repository provides dataloaders and data preprocessing modules for mlpack library.
 It also provides utility function required required for downloading, extracting and processing


### PR DESCRIPTION
I have updated readme a little bit to show use of data loaders and pre-processor functions. I have left utility functions out for now. Let me know if I should include them.
One other is I have copied the Contribution.md from mlpack repo.
I think it makes sense to have a wiki page for data loaders, utility functions and pre-processors. Kindly let me know if the wiki page idea makes sense. Thanks a lot.
Looking forward to your suggestions.
Regards.