### PR TITLE
Linux Build Fix.

### DIFF
--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -22,7 +22,7 @@ steps:
 
     sudo apt-get install -y --allow-unauthenticated liblapack-dev g++ libboost1.70-dev libarmadillo-dev xz-utils
 
-    curl https://ftp.fau.de/macports/distfiles/armadillo/armadillo-8.400.0.tar.xz | tar -xvJ && cd armadillo*
+    curl https://data.kurg.org/armadillo-8.400.0.tar.xz | tar -xvJ && cd armadillo*
     cmake . && make && sudo make install && cd ..
   displayName: 'Install Build Dependencies'
 


### PR DESCRIPTION
> The source (https://ftp.fau.de/) we use to download armadillo has a faulty RAID controller:
"The machine has a faulty RAID controller. Until a replacement part arrives, bad performance and crashes are to be expected. Mirrors will NOT be updated for now. Sorry for the inconvenience."

Refer to similar PR mlpack/mlpack#2441