### PR TITLE
Add YOLO class.

### DIFF
--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 project(models)
 
 add_subdirectory(darknet)
+add_subdirectory(yolo)
 
 # Add directory name to sources.
 set(DIR_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/)

--- a/models/yolo/CMakeLists.txt
+++ b/models/yolo/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+project(yolo)
+
+set(DIR_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/)
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../../")
+
+set(SOURCES
+  yolo.hpp
+  yolo_impl.hpp
+)
+
+foreach(file ${SOURCES})
+  set(DIR_SRCS ${DIR_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/${file})
+endforeach()
+
+set(DIRS ${DIRS} ${DIR_SRCS} PARENT_SCOPE)

--- a/models/yolo/yolo.hpp
+++ b/models/yolo/yolo.hpp
@@ -158,9 +158,7 @@ class YOLO
         ", " << outSize << ")" << std::endl;
 
     if (batchNorm)
-    {
       bottleNeck->Add(new BatchNorm<>(outSize, 1e-8, false));
-    }
 
     bottleNeck->Add(new LeakyReLU<>(0.01));
 

--- a/models/yolo/yolo.hpp
+++ b/models/yolo/yolo.hpp
@@ -61,7 +61,7 @@ class YOLO
    * @param inputHeight Height of the input image.
    * @param yoloVersion Version of YOLO model.
    * @param numClasses Optional number of classes to classify images into,
-   *                   only to be specified if includeTop is  true.
+   *     only to be specified if includeTop is  true.
    * @param numBoxes Number of bounding boxes per image.
    * @param featureSizeWidth Width of output feature map.
    * @param featureSizeHeight Height of output feature map.
@@ -83,16 +83,15 @@ class YOLO
    * YOLO constructor intializes input shape and number of classes.
    *
    * @param inputShape A three-valued tuple indicating input shape.
-   *                   First value is number of Channels (Channels-First).
-   *                   Second value is input height.
-   *                   Third value is input width.
+   *     First value is number of Channels (Channels-First).
+   *     Second value is input height. Third value is input width.
    * @param yoloVersion Version of YOLO model.
    * @param numClasses Optional number of classes to classify images into,
-   *                   only to be specified if includeTop is  true.
+   *     only to be specified if includeTop is  true.
    * @param numBoxes Number of bounding boxes per image.
    * @param featureShape A twp-valued tuple indicating width and height of output feature
-   *                     map.
-   * @param weights One of 'none', 'cifar10'(pre-training on CIFAR10) or path to weights.
+   *     map.
+   * @param weights One of 'none', 'voc'(pre-training on VOC) or path to weights.
    */
   YOLO(const std::tuple<size_t, size_t, size_t> inputShape,
        const std::string yoloVersion = "v1-tiny",
@@ -116,7 +115,7 @@ class YOLO
    * Adds Convolution Block.
    *
    * @tparam SequentialType Layer type in which convolution block will
-   *                        be added.
+   *     be added.
    *
    * @param inSize Number of input maps.
    * @param outSize Number of output maps.
@@ -127,9 +126,9 @@ class YOLO
    * @param padW Padding width of the input.
    * @param padH Padding height of the input.
    * @param batchNorm Boolean to determine whether a batch normalization
-   *                  layer is added.
+   *     layer is added.
    * @param baseLayer Layer in which Convolution block will be added, if
-   *                  NULL added to YOLO FFN.
+   *     NULL added to YOLO FFN.
    */
   template<typename SequentialType = Sequential<>>
   void ConvolutionBlock(const size_t inSize,
@@ -173,7 +172,7 @@ class YOLO
    *
    * @param factor The factor by which input dimensions will be divided.
    * @param type One of "max" or "mean". Determines whether add mean pooling
-   *             layer or max pooling layer.
+   *     layer or max pooling layer.
    */
   void PoolingBlock(const size_t factor = 2,
                     const std::string type = "max")

--- a/models/yolo/yolo.hpp
+++ b/models/yolo/yolo.hpp
@@ -91,7 +91,7 @@ class YOLO
    *                   only to be specified if includeTop is  true.
    * @param numBoxes Number of bounding boxes per image.
    * @param featureShape A twp-valued tuple indicating width and height of output feature
-   *                    map.
+   *                     map.
    * @param weights One of 'none', 'cifar10'(pre-training on CIFAR10) or path to weights.
    */
   YOLO(const std::tuple<size_t, size_t, size_t> inputShape,

--- a/models/yolo/yolo.hpp
+++ b/models/yolo/yolo.hpp
@@ -1,0 +1,242 @@
+/**
+ * @file yolo.hpp
+ * @author Kartik Dutt
+ * 
+ * Definition of Yolo models.
+ * 
+ * For more information, kindly refer to the following paper.
+ * 
+ * Paper for YOLOv1.
+ *
+ * @code
+ * @article{Redmon2016,
+ *  author = {Joseph Redmon, Santosh Divvala, Ross Girshick, Ali Farhadi},
+ *  title = {You Only Look Once : Unified, Real-Time Object Detection},
+ *  year = {2016},
+ *  url = {https://arxiv.org/pdf/1506.02640.pdf}
+ * }
+ * @endcode
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+
+#ifndef MODELS_YOLO_HPP
+#define MODELS_YOLO_HPP
+
+#include <mlpack/core.hpp>
+#include <mlpack/methods/ann/layer/layer.hpp>
+#include <mlpack/methods/ann/ffn.hpp>
+#include <mlpack/methods/ann/layer/layer_types.hpp>
+#include <mlpack/methods/ann/init_rules/random_init.hpp>
+#include <mlpack/methods/ann/init_rules/he_init.hpp>
+#include <mlpack/methods/ann/init_rules/glorot_init.hpp>
+
+namespace mlpack {
+namespace ann /** Artificial Neural Network. */{
+
+/**
+ * Definition of a YOLO object detection models.
+ * 
+ * @tparam OutputLayerType The output layer type used to evaluate the network.
+ * @tparam InitializationRuleType Rule used to initialize the weight matrix.
+ * @tparam YOLOVersion Version of YOLO model.
+ */
+template<
+  typename OutputLayerType = NegativeLogLikelihood<>,
+  typename InitializationRuleType = RandomInitialization,
+  std::string YOLOVersion = "v1-tiny"
+>
+class YOLO
+{
+ public:
+  //! Create the YOLO model.
+  YOLO();
+
+  /**
+   * YOLO constructor intializes input shape and number of classes.
+   *
+   * @param inputChannels Number of input channels of the input image.
+   * @param inputWidth Width of the input image.
+   * @param inputHeight Height of the input image.
+   * @param numClasses Optional number of classes to classify images into,
+   *                   only to be specified if includeTop is  true.
+   * @param numBoxes Number of bounding boxes per image.
+   * @param featureSizeWidth Width of output feature map.
+   * @param featureSizeHeight Height of output feature map.
+   * @param weights One of 'none', 'voc'(pre-training on VOC-2012) or path to weights.
+   * @param includeTop Must be set to true if weights are set.
+   */
+  YOLO(const size_t inputChannel,
+       const size_t inputWidth,
+       const size_t inputHeight,
+       const size_t numClasses = 20,
+       const size_t numBoxes = 2,
+       const size_t featureSizeWidth = 7,
+       const size_t featureSizeHeight = 7,
+       const std::string& weights = "none",
+       const bool includeTop = true);
+
+  /**
+   * YOLO constructor intializes input shape and number of classes.
+   *
+   * @param inputShape A three-valued tuple indicating input shape.
+   *                   First value is number of Channels (Channels-First).
+   *                   Second value is input height.
+   *                   Third value is input width..
+   * @param numClasses Optional number of classes to classify images into,
+   *                   only to be specified if includeTop is  true.
+   * @param numBoxes Number of bounding boxes per image.
+   * @param featureShape A twp-valued tuple indicating width and height of output feature
+   *                    map.
+   * @param weights One of 'none', 'cifar10'(pre-training on CIFAR10) or path to weights.
+   */
+  YOLO(const std::tuple<size_t, size_t, size_t> inputShape,
+       const size_t numClasses = 1000,
+       const size_t numBoxes = 2,
+       const std::tuple<size_t, size_t> featureShape,
+       const std::string& weights = "none",
+       const bool includeTop = true);
+
+  //! Get Layers of the model.
+  FFN<OutputLayerType, InitializationRuleType>& GetModel() { return yolo; }
+
+  //! Load weights into the model.
+  void LoadModel(const std::string& filePath);
+
+  //! Save weights for the model.
+  void SaveModel(const std::string& filePath);
+
+ private:
+  /**
+   * Adds Convolution Block.
+   *
+   * @tparam SequentialType Layer type in which convolution block will
+   *                        be added.
+   *
+   * @param inSize Number of input maps.
+   * @param outSize Number of output maps.
+   * @param kernelWidth Width of the filter/kernel.
+   * @param kernelHeight Height of the filter/kernel.
+   * @param strideWidth Stride of filter application in the x direction.
+   * @param strideHeight Stride of filter application in the y direction.
+   * @param padW Padding width of the input.
+   * @param padH Padding height of the input.
+   * @param batchNorm Boolean to determine whether a batch normalization
+   *                  layer is added.
+   * @param baseLayer Layer in which Convolution block will be added, if
+   *                  NULL added to YOLO FFN.
+   */
+  template<typename SequentialType = Sequential<>>
+  void ConvolutionBlock(const size_t inSize,
+                        const size_t outSize,
+                        const size_t kernelWidth,
+                        const size_t kernelHeight,
+                        const size_t strideWidth = 1,
+                        const size_t strideHeight = 1,
+                        const size_t padW = 0,
+                        const size_t padH = 0,
+                        const bool batchNorm = false,
+                        SequentialType* baseLayer = NULL)
+  {
+    Sequential<>* bottleNeck = new Sequential<>();
+    bottleNeck->Add(new Convolution<>(inSize, outSize, kernelWidth,
+        kernelHeight, strideWidth, strideHeight, padW, padH, inputWidth,
+        inputHeight));
+
+    // Update inputWidth and input Height.
+    inputWidth = ConvOutSize(inputWidth, kernelWidth, strideWidth, padW);
+    inputHeight = ConvOutSize(inputHeight, kernelHeight, strideHeight, padH);
+
+    if (batchNorm)
+    {
+      bottleNeck->Add(new BatchNorm<>(outSize, 1e-8, false));
+    }
+
+    bottleNeck->Add(new LeakyReLU<>());
+
+    if (baseLayer != NULL)
+      baseLayer->Add(bottleNeck);
+    else
+      yolo.Add(bottleNeck);
+  }
+
+  /**
+   * Adds Pooling Block.
+   *
+   * @param factor The factor by which input dimensions will be divided.
+   * @param type One of "max" or "mean". Determines whether add mean pooling
+   *             layer or max pooling layer.
+   */
+  void PoolingBlock(const size_t factor = 2,
+                    const std::string type = "max")
+  {
+    if (type == "max")
+    {
+      yolo.Add(new AdaptiveMaxPooling<>(std::ceil(inputWidth * 1.0 / factor),
+          std::ceil(inputHeight * 1.0 / factor)));
+    }
+    else
+    {
+      yolo.Add(new AdaptiveMeanPooling<>(std::ceil(inputWidth * 1.0 /
+          factor), std::ceil(inputHeight * 1.0 / factor)));
+    }
+
+    // Update inputWidth and inputHeight.
+    inputWidth = std::ceil(inputWidth * 1.0 / factor);
+    inputHeight = std::ceil(inputHeight * 1.0 / factor);
+  }
+
+  /**
+   * Return the convolution output size.
+   *
+   * @param size The size of the input (row or column).
+   * @param k The size of the filter (width or height).
+   * @param s The stride size (x or y direction).
+   * @param padding The size of the padding (width or height) on one side.
+   * @return The convolution output size.
+   */
+  size_t ConvOutSize(const size_t size,
+                     const size_t k,
+                     const size_t s,
+                     const size_t padding)
+  {
+    return std::floor(size + 2 * padding - k) / s + 1;
+  }
+
+  //! Locally stored YOLO Model.
+  FFN<OutputLayerType, InitializationRuleType> yolo;
+
+  //! Locally stored width of the image.
+  size_t inputWidth;
+
+  //! Locally stored height of the image.
+  size_t inputHeight;
+
+  //! Locally stored number of channels in the image.
+  size_t inputChannel;
+
+  //! Locally stored number of output classes.
+  size_t numClasses;
+
+  //! Locally stored number of output bounding boxes.
+  size_t numBoxes;
+
+  //! Locally stored width of output feature map.
+  size_t featureWidth;
+
+  //! Locally stored height of output feature map.
+  size_t featureHeight;
+
+  //! Locally stored type of pre-trained weights.
+  std::string weights;
+}; // YOLO class.
+
+} // namespace ann
+} // namespace mlpack
+
+# include "yolo_impl.hpp"
+
+#endif

--- a/models/yolo/yolo_impl.hpp
+++ b/models/yolo/yolo_impl.hpp
@@ -126,11 +126,11 @@ YOLO<OutputLayerType, InitializationRuleType, YOLOVersion>::YOLO(
     {
       yolo.Add(new Linear<>(inputWidth * inputHeight * outChannels, 4096));
       yolo.Add(new LeakyReLU<>());
-      yolo.Add(4096, featureWidth * featureHeight * (5 * numBoxes + numClasses));
+      yolo.Add(4096, featureWidth * featureHeight * (5 *
+          numBoxes + numClasses));
       yolo.Add(new Sigmoid<>());
-      // See if we need to reshape here.
     }
-  }
+
     yolo.ResetParameters();
   }
 }

--- a/models/yolo/yolo_impl.hpp
+++ b/models/yolo/yolo_impl.hpp
@@ -1,0 +1,168 @@
+/**
+ * @file yolo_impl.hpp
+ * @author Kartik Dutt
+ *
+ * Implementation of YOLO models using mlpack.
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef MODELS_YOLO_IMPL_HPP
+#define MODELS_YOLO_IMPL_HPP
+
+#include "yolo.hpp"
+
+namespace mlpack {
+namespace ann {
+
+template<
+    typename OutputLayerType,
+    typename InitializationRuleType,
+    std::string YOLOVersion = "v1-tiny"
+>
+YOLO<OutputLayerType, InitializationRuleType, YOLOVersion>::YOLO() :
+    inputChannel(0),
+    inputWidth(0),
+    inputHeight(0),
+    numClasses(0),
+    numBoxes(0),
+    featureWidth(0),
+    featureHeight(0),
+    weights("none")
+{
+  // Nothing to do here.
+}
+
+template<
+    typename OutputLayerType,
+    typename InitializationRuleType,
+    std::string YOLOVersion = "v1-tiny"
+>
+YOLO<OutputLayerType, InitializationRuleType, YOLOVersion>::YOLO(
+  const size_t inputChannel,
+  const size_t inputWidth,
+  const size_t inputHeight,
+  const size_t numClasses,
+  const size_t numBoxes,
+  const size_t featureWidth,
+  const size_t featureHeight,
+  const std::string& weights,
+  const bool includeTop) :
+  YOLO<OutputLayerType, InitializationRuleType, YOLOVersion>(
+    std::tuple<size_t, size_t, size_t>(
+      inputChannel,
+      inputWidth,
+      inputHeight),
+      numClasses,
+      numBoxes,
+      std::tuple<size_t, size_t>(featureWidth, featureHeight),
+      weights,
+      includeTop)
+{
+  // Nothing to do here.
+}
+
+template<
+     typename OutputLayerType,
+     typename InitializationRuleType,
+     std::string YOLOVersion
+>
+YOLO<OutputLayerType, InitializationRuleType, YOLOVersion>::YOLO(
+    const std::tuple<size_t, size_t, size_t> inputShape,
+    const size_t numClasses,
+    const size_t numBoxes,
+    const std::tuple<size_t, size_t> featureShape,
+    const std::string& weights,
+    const bool includeTop) :
+    inputChannel(std::get<0>(inputShape)),
+    inputWidth(std::get<1>(inputShape)),
+    inputHeight(std::get<2>(inputShape)),
+    numClasses(numClasses),
+    numBoxes(numBoxes),
+    featureWidth(std::get<0>(featureShape)),
+    featureHeight(std::get<1>(featureShape)),
+    weights(weights)
+{
+  std::set<string> supportedVersion({"v1-tiny"});
+  mlpack::Log::Assert(supportedVersion.count(YOLOVersion),
+      "Unsupported YOLO version. Trying to find :", YOLOVersion);
+
+  if (weights == "voc")
+  {
+    // Download weights here.
+    LoadModel("./../weights/YOLO/yolo" + YOLOVersion + "_voc.bin");
+    return;
+  }
+  else if (weights != "none")
+  {
+    LoadModel(weights);
+    return;
+  }
+
+  if (YOLOVersion == "v1-tiny")
+  {
+    yolo.Add(new IdentityLayer<>());
+
+    // Convolution and activation function in a block.
+    ConvolutionBlock(inputChannel, 16, 3, 3, 1, 1, 1, 1, true);
+    PoolingBlock(2);
+
+    size_t numBlocks = 5;
+    size_t outChannels = 16;
+    for (size_t blockId = 0; blockId < 4; blockId++)
+    {
+      ConvolutionBlock(outChannels, outChannels * 2, 3, 3, 1, 1, 1, 1, true);
+      PoolingBlock(2);
+      outChannels *= 2;
+    }
+
+    numBlocks = 2;
+    for (size_t blockId = 0; blockId < numBlocks; blockId++)
+      ConvolutionBlock(outChannels, outChannels, 3, 3, 1, 1, 1, 1, true);
+
+    if (includeTop)
+    {
+      yolo.Add(new Linear<>(inputWidth * inputHeight * outChannels, 4096));
+      yolo.Add(new LeakyReLU<>());
+      yolo.Add(4096, featureWidth * featureHeight * (5 * numBoxes + numClasses));
+      yolo.Add(new Sigmoid<>());
+      // See if we need to reshape here.
+    }
+  }
+    yolo.ResetParameters();
+  }
+}
+
+template<
+    typename OutputLayerType,
+    typename InitializationRuleType,
+    std::string YOLOVersion
+>
+void YOLO<
+    OutputLayerType, InitializationRuleType, YOLOVersion
+>::LoadModel(const std::string& filePath)
+{
+  data::Load(filePath, "yolo" + YOLOVersion, yolo);
+  Log::Info << "Loaded model." << std::endl;
+}
+
+template<
+     typename OutputLayerType,
+     typename InitializationRuleType,
+     std::string YOLOVersion
+>
+void YOLO<
+    OutputLayerType, InitializationRuleType, YOLOVersion
+>::SaveModel(const std::string& filePath)
+{
+  Log::Info<< "Saving model." << std::endl;
+  data::Save(filePath, "yolo" + YOLOVerson, yolo);
+  Log::Info << "Model saved in " << filePath << "." << std::endl;
+}
+
+} // namespace ann
+} // namespace mlpack
+
+#endif

--- a/models/yolo/yolo_impl.hpp
+++ b/models/yolo/yolo_impl.hpp
@@ -66,8 +66,8 @@ YOLO<OutputLayerType, InitializationRuleType>::YOLO(
 }
 
 template<
-     typename OutputLayerType,
-     typename InitializationRuleType
+    typename OutputLayerType,
+    typename InitializationRuleType
 >
 YOLO<OutputLayerType, InitializationRuleType>::YOLO(
     const std::tuple<size_t, size_t, size_t> inputShape,
@@ -149,8 +149,8 @@ void YOLO<
 }
 
 template<
-     typename OutputLayerType,
-     typename InitializationRuleType
+    typename OutputLayerType,
+    typename InitializationRuleType
 >
 void YOLO<
     OutputLayerType, InitializationRuleType

--- a/models/yolo/yolo_impl.hpp
+++ b/models/yolo/yolo_impl.hpp
@@ -111,23 +111,22 @@ YOLO<OutputLayerType, InitializationRuleType, YOLOVersion>::YOLO(
 
     size_t numBlocks = 5;
     size_t outChannels = 16;
-    for (size_t blockId = 0; blockId < 4; blockId++)
+    for (size_t blockId = 0; blockId < numBlocks; blockId++)
     {
       ConvolutionBlock(outChannels, outChannels * 2, 3, 3, 1, 1, 1, 1, true);
       PoolingBlock(2);
       outChannels *= 2;
     }
 
-    numBlocks = 2;
-    for (size_t blockId = 0; blockId < numBlocks; blockId++)
-      ConvolutionBlock(outChannels, outChannels, 3, 3, 1, 1, 1, 1, true);
+    ConvolutionBlock(outChannels, outChannels * 2, 3, 3, 1, 1, 1, 1, true);
+    outChannels *= 2;
+    ConvolutionBlock(outChannels, 256, 3, 3, 1, 1, 1, 1, true);
+    outChannels 256;
 
     if (includeTop)
     {
-      yolo.Add(new Linear<>(inputWidth * inputHeight * outChannels, 4096));
-      yolo.Add(new LeakyReLU<>());
-      yolo.Add(4096, featureWidth * featureHeight * (5 *
-          numBoxes + numClasses));
+      yolo.Add(new Linear<>(inputWidth * inputHeight * outChannels,
+          featureWidth * featureHeight * (5 * numBoxes + numClasses)));
       yolo.Add(new Sigmoid<>());
     }
 

--- a/tests/ffn_model_tests.cpp
+++ b/tests/ffn_model_tests.cpp
@@ -14,6 +14,7 @@
 #include <ensmallen.hpp>
 #include <dataloader/dataloader.hpp>
 #include <models/darknet/darknet.hpp>
+#include <models/yolo/yolo.hpp>
 #include <boost/test/unit_test.hpp>
 
 // Use namespaces for convenience.
@@ -40,6 +41,21 @@ BOOST_AUTO_TEST_CASE(DarknetModelTest)
   darknet53.GetModel().Predict(input, output);
   BOOST_REQUIRE_EQUAL(output.n_cols, 1);
   BOOST_REQUIRE_EQUAL(output.n_rows, 1000);
+}
+
+/**
+ * Simple test for YOLOv1 model.
+ */
+BOOST_AUTO_TEST_CASE(YOLOV1ModelTest)
+{
+  mlpack::ann::YOLO<> yolo(3, 448, 448);
+  arma::mat input(448 * 448 * 3, 1), output;
+  input.ones();
+
+  // Check output shape.
+  yolo.GetModel().Predict(input, output);
+  BOOST_REQUIRE_EQUAL(output.n_cols, 1);
+  BOOST_REQUIRE_EQUAL(output.n_rows, 7 * 7 * (5 * 2 + 20));
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
Hey everyone,
This PR aims to YOLO class to the models repo. The following is the TO-DO list:

- [x] Add PreProcessor Function (Convert DataLoader annotations to YOLO targets). (I'll add this by 10.07.20)

- [x] Add Detection stage for the YOLO class (Where loss is calculated, feature maps are converted to understandable format).

- [x] Add YOLO model architecture.
