### PR TITLE
Add Imagenet PreProcessor

### DIFF
--- a/dataloader/preprocessor.hpp
+++ b/dataloader/preprocessor.hpp
@@ -65,7 +65,7 @@ class PreProcessor
    * @param imageHeight Height of the image in dataset.
    * @param imageDepth Depth / Number of channels of the image in dataset.
    */
-  static void ChannelFirstImages(Dataset& trainFeatures,
+  static void ChannelFirstImages(DatasetX& trainFeatures,
                                  const size_t imageWidth,
                                  const size_t imageHeight,
                                  const size_t imageDepth,

--- a/dataloader/preprocessor.hpp
+++ b/dataloader/preprocessor.hpp
@@ -79,8 +79,9 @@ class PreProcessor
       size_t currentOffset = 0;
       for (size_t i = 0; i < inputTemp.n_slices; i++)
       {
-          trainFeatures.col(idx)(arma::span(currentOffset, currentOffset + inputTemp.slice(i).n_elem - 1),
-              arma::span()) = arma::vectorise(inputTemp.slice(i).t());
+          trainFeatures.col(idx)(arma::span(currentOffset, currentOffset +
+              inputTemp.slice(i).n_elem - 1), arma::span()) =
+              arma::vectorise(inputTemp.slice(i).t());
           currentOffset += inputTemp.slice(i).n_elem;
       }
     }

--- a/dataloader/preprocessor.hpp
+++ b/dataloader/preprocessor.hpp
@@ -55,6 +55,45 @@ class PreProcessor
   {
     // Nothing to do here. Added to match the rest of the codebase.
   }
+
+  /**
+   * Converts image to channel first format used in PyTorch. Performs the same function
+   * as torch.transforms.ToTensor().
+   *
+   * @param trainFeatures Input features that will be converted into channel first format.
+   * @param imageWidth Width of the image in dataset.
+   * @param imageHeight Height of the image in dataset.
+   * @param imageDepth Depth / Number of channels of the image in dataset.
+   */
+  static void ChannelFirstImages(Dataset& trainFeatures,
+                                 const size_t imageWidth,
+                                 const size_t imageHeight,
+                                 const size_t imageDepth,
+                                 bool normalize = true)
+  {
+    for (size_t idx = 0; idx < trainFeatures.n_cols; idx++)
+    {
+      // Create a copy of the current image so that the image isn't affected.
+      arma::cube inputTemp(trainFeatures.col(idx).memptr(), 3, 224, 224);
+
+      size_t currentOffset = 0;
+      for (size_t i = 0; i < inputTemp.n_slices; i++)
+      {
+          trainFeatures.col(idx)(arma::span(currentOffset, currentOffset + inputTemp.slice(i).n_elem - 1),
+              arma::span()) = arma::vectorise(inputTemp.slice(i).t());
+          currentOffset += inputTemp.slice(i).n_elem;
+      }
+    }
+
+    if (normalize)
+    {
+      // Convert each element to uint8 first and then divide by 255.
+      for (size_t i = 0; i < trainFeatures.n_elem; i++)
+      {
+        trainFeatures(i) = ((uint8_t) (trainFeatures(i)) / 255.0);
+      }
+    }
+  }
 };
 
 #endif


### PR DESCRIPTION
Hey everyone,
This PR adds the functional equivalent of PyTorch's to tensor function. Since we have transferred weights from PyTorch the input Feature matrix also need to match with PyTorch so this PR adds the same.
[Docs](https://pytorch.org/docs/stable/_modules/torchvision/transforms/transforms.html#ToTensor).