### PR TITLE
Deprecation of ubuntu 16.04 in pipeline 

### DIFF
--- a/.ci/ci.yaml
+++ b/.ci/ci.yaml
@@ -28,7 +28,7 @@ jobs:
 - job: Linux
   timeoutInMinutes: 360
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
 
   strategy:
     matrix:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39410692/123819135-2b5e2f00-d917-11eb-9866-8434148569f3.png)
The support will go out in September and azure only uses the LTS versions of ubuntu and tags them with `ubuntu-latest` so using this should fix us and wouldn't need any change or a long time but I can also see the benefit of using `ubuntu-20.04` where it doesn't changes and we can have a testing env we know.   

Let me know your opinions. 