### PR TITLE
Use catch2 instead of ctest

### DIFF
--- a/.ci/linux-steps.yaml
+++ b/.ci/linux-steps.yaml
@@ -49,7 +49,7 @@ steps:
   displayName: 'Build models'
 
 # Run CTests.
-- script: cd build/tests/ && sudo CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test .
+- script: cd build/bin/ && ./models_test -x 50
   displayName: 'Run tests via ctest'
 
 # Publish test results to Azure Pipelines

--- a/.ci/macos-steps.yaml
+++ b/.ci/macos-steps.yaml
@@ -37,7 +37,7 @@ steps:
   displayName: 'Build models'
 
 # Run CTests.
-- script: cd build/tests/ && sudo CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test .
+- script: cd build/bin/ && ./models_test -x 50
   displayName: 'Run tests via ctest'
 
 # Publish test results to Azure Pipelines

--- a/.ci/windows-steps.yaml
+++ b/.ci/windows-steps.yaml
@@ -138,6 +138,8 @@ steps:
     dir
     cd bin/
     dir
+    cd Release/
+    dir
     ./models_test.exe -x 50
   displayName: 'Run tests via ctest'
 

--- a/.ci/windows-steps.yaml
+++ b/.ci/windows-steps.yaml
@@ -134,13 +134,8 @@ steps:
 
 # Run tests via ctest.
 - bash: |
-    cd build/
-    dir
-    cd bin/
-    dir
-    cd Release/
-    dir
-    ./models_test.exe -x 50
+    cd build/bin
+    ./Release/models_test.exe -x 50
   displayName: 'Run tests via ctest'
 
 # Publish test results to Azure Pipelines

--- a/.ci/windows-steps.yaml
+++ b/.ci/windows-steps.yaml
@@ -128,14 +128,14 @@ steps:
   displayName: 'Build models'
 
 - powershell: |
-    cp build\*.dll build\tests
-    cp build\*.lib build\tests
+    cp build\*.dll build\bin\Release
+    cp build\*.lib build\bin\Release
   displayName: 'Copy lib and dll files to build/bin'
 
 # Run tests via ctest.
 - bash: |
-    cd build/bin
-    ./Release/models_test.exe -x 50
+    cd build/bin/Release/
+    ./models_test.exe -x 50
   displayName: 'Run tests via ctest'
 
 # Publish test results to Azure Pipelines

--- a/.ci/windows-steps.yaml
+++ b/.ci/windows-steps.yaml
@@ -134,8 +134,11 @@ steps:
 
 # Run tests via ctest.
 - bash: |
-    cd build/tests
-    CTEST_OUTPUT_ON_FAILURE=1 ctest -T Test -C Release .
+    cd build/
+    dir
+    cd bin/
+    dir
+    ./models_test.exe -x 50
   displayName: 'Run tests via ctest'
 
 # Publish test results to Azure Pipelines


### PR DESCRIPTION
ctest reports tests to pass even if they are failed, this is done just so we know if some tests fail. 

reference comment: https://github.com/mlpack/models/pull/63#issuecomment-870899105

reverting back on #69 closed it automatically so creating this PR. 