### PR TITLE
yolov3-tiny implementation

### DIFF
--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -9,7 +9,9 @@ set(DIR
   squeezenet
   vgg
   xception
-  yolo)
+  yolo
+  yolov3_tiny
+)
 
 foreach(dir ${DIR})
   add_subdirectory(${dir})

--- a/models/yolov3_tiny/CMakeLists.txt
+++ b/models/yolov3_tiny/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+project(yolov3_tiny_v1)
+
+set(DIR_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/)
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../../")
+
+set(SOURCES
+  yolov3_tiny.hpp
+  yolov3_tiny_impl.cpp
+)
+set(EXEC
+  main.cpp
+)
+
+foreach(file ${SOURCES})
+  set(DIR_SRCS ${DIR_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/${file})
+endforeach()
+
+set(DIRS ${DIRS} ${DIR_SRCS} PARENT_SCOPE)
+

--- a/models/yolov3_tiny/yolov3_layer.hpp
+++ b/models/yolov3_tiny/yolov3_layer.hpp
@@ -1,0 +1,12 @@
+
+#ifndef YOLO_LAYER_HPP
+#define YOLO_LAYER_HPP
+
+#include <mlpack/prereqs.hpp>
+#include <mlpack/methods/ann/layer/layer.hpp>
+
+namespace mlpack {
+}
+
+
+#endif

--- a/models/yolov3_tiny/yolov3_layer.hpp
+++ b/models/yolov3_tiny/yolov3_layer.hpp
@@ -1,12 +1,98 @@
-
+/**
+ * @author Andrew Furey
+ *
+ * Definition of the YOLO layer for object detection
+ *
+ * mlpack is free software; you may redistribute it and/or modify it under the
+ * terms of the 3-clause BSD license.  You should have received a copy of the
+ * 3-clause BSD license along with mlpack.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
 #ifndef YOLO_LAYER_HPP
 #define YOLO_LAYER_HPP
 
 #include <mlpack/prereqs.hpp>
-#include <mlpack/methods/ann/layer/layer.hpp>
+#include <mlpack/methods/ann.hpp>
 
 namespace mlpack {
-}
 
+/*
+ * Implementation of the yolo layer for object detection. 
+ *
+ * @tparam MatType Matrix representation to accept as input and use for
+ *    computation.
+ */
+template<typename MatType>
+class Yolo : public Layer<MatType>
+{
+ public:
+  /**
+   * Create the Yolo object.  The output size of the layer will be the same
+   * as the input size.
+   */
+  Yolo();
+
+  //! Clone the Yolo object. This handles polymorphism correctly.
+  Yolo* Clone() const { return new Yolo(*this); }
+
+  // Virtual destructor.
+  virtual ~Yolo() { }
+
+  //! Copy the given Yolo layer.
+  Yolo(const Yolo& other);
+  //! Take ownership of the given Yolo layer.
+  Yolo(Yolo&& other);
+  //! Copy the given Yolo layer.
+  Yolo& operator=(const Yolo& other);
+  //! Take ownership of the given Yolo layer.
+  Yolo& operator=(Yolo&& other);
+
+  /**
+   * Forward pass
+   */
+  void Forward(const MatType& input, MatType& output);
+
+  /**
+   * Backward pass
+   */
+  void Backward(const MatType& /* input */,
+                const MatType& /* output */,
+                const MatType& gy,
+                MatType& g);
+
+  /**
+   * Calculate the gradient using the output and the input activation.
+   *
+   * @param * (input) The propagated input.
+   * @param error The calculated error.
+   * @param gradient The calculated gradient.
+   */
+  void Gradient(const MatType& /* input */,
+                const MatType& error,
+                MatType& gradient);
+
+  //! Return the weights of the network.
+  const MatType& Parameters() const { return weights; }
+  //! Modify the weights of the network.
+  MatType& Parameters() { return weights; }
+
+  //! Compute the output dimensions of the layer, based on the internal values
+  //! of `InputDimensions()`.
+  void ComputeOutputDimensions();
+
+  //! Set the weights of the layer to use the given memory.
+  void SetWeights(const MatType& weightsIn);
+
+  /**
+   * Serialize the layer.
+   */
+  template<typename Archive>
+  void serialize(Archive& ar, const uint32_t /* version */);
+
+ private:
+  //! Locally-stored weight object.
+  MatType weights;
+}; // Yolo class
+} // namespace mlpack
 
 #endif

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -1,0 +1,56 @@
+#ifndef MODELS_MODELS_YOLOV3_TINY_YOLOV3_TINY_HPP
+#define MODELS_MODELS_YOLOV3_TINY_YOLOV3_TINY_HPP
+
+#include <mlpack/methods/ann/layer/adaptive_max_pooling.hpp>
+#include <mlpack/methods/ann/layer/add.hpp>
+#include <mlpack/methods/ann/layer/batch_norm.hpp>
+#include <mlpack/methods/ann/layer/max_pooling.hpp>
+#include <mlpack/methods/ann/layer/multi_layer.hpp>
+
+#define MLPACK_ENABLE_ANN_SERIALIZATION
+#include <mlpack.hpp>
+
+namespace mlpack {
+namespace models {
+
+template<typename MatType>
+class YoloV3Tiny {
+public:
+  YoloV3Tiny(const size_t inputWidth,
+	     const size_t inputHeight,
+	     const size_t inputChannels,
+	     const size_t numClasses = 80,
+	     const float ignoreThresh = 0.7
+	     ) :
+	inputWidth(inputWidth),
+	inputHeight(inputHeight),
+	inputChannels(inputChannels),
+	numClasses(numClasses),
+	ignoreThresh(ignoreThresh)
+	{}
+
+  ~YoloV3Tiny() {}
+
+  void LoadModel(const std::string &filePath);
+  void SaveModel(const std::string &filePath);
+
+private:
+  MultiLayer<MatType>* MaxPoolBlock(const size_t size) {
+    return new MaxPooling(inputWidth / (double)size, inputHeight / (double)size);
+  }
+
+  void Darknet19() {}
+
+  size_t inputWidth;
+  size_t inputHeight;
+  size_t inputChannels;
+  size_t numClasses;
+  float ignoreThresh;
+};
+
+} // namespace models
+} // namespace mlpack
+
+#include "yolov3_tiny_impl.hpp"
+
+#endif

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -8,6 +8,7 @@
 #include <mlpack/methods/ann/layer/leaky_relu.hpp>
 #include <mlpack/methods/ann/layer/max_pooling.hpp>
 #include <mlpack/methods/ann/layer/multi_layer.hpp>
+#include <mlpack/methods/ann/layer/concat.hpp>
 #include <mlpack/methods/ann/layer/padding.hpp>
 
 #include "yolov3_tiny_loss.hpp"
@@ -34,44 +35,89 @@ public:
 	inputChannels(inputChannels),
 	numClasses(numClasses)
   {
-    layers.resize(17);
-    layers[0] = ConvolutionalBlock(3, 16);
-    layers[1] = PoolingBlock(2, 2);
-    layers[2] = ConvolutionalBlock(3, 32);
-    layers[3] = PoolingBlock(2, 2);
-    layers[4] = ConvolutionalBlock(3, 64);
-    layers[5] = PoolingBlock(2, 2);
-    layers[6] = ConvolutionalBlock(3, 128);
-    layers[7] = PoolingBlock(2, 2);
-    layers[8] = ConvolutionalBlock(3, 256);
-    layers[9] = PoolingBlock(2, 2);
-    layers[10]= ConvolutionalBlock(3, 512);
-    layers[11]= PoolingBlock(2, 1, 0.5, 0.5);
-    layers[12]= ConvolutionalBlock(3, 1024);
-    layers[13]= ConvolutionalBlock(1, 256, 1, 0);
-    layers[14]= ConvolutionalBlock(3, 512);
-    layers[15]= ConvolutionalBlock(1, 255, 1, 0, false, false);
-    layers[16]= YOLOv3Block({3, 4, 5});
+    large.InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, 1});
+    small.InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, 1});
+    
+    large.template Add(ConvolutionalBlock(3, 16));//0
+    large.template Add(PoolingBlock(2, 2));//1
+    large.template Add(ConvolutionalBlock(3, 32));//2
+    large.template Add(PoolingBlock(2, 2));//3
+    large.template Add(ConvolutionalBlock(3, 64));//4
+    large.template Add(PoolingBlock(2, 2));//5
+    large.template Add(ConvolutionalBlock(3, 128));//6
+    large.template Add(PoolingBlock(2, 2));//7
+    large.template Add(ConvolutionalBlock(3, 256));//8
+    large.template Add(PoolingBlock(2, 2));//9
+    large.template Add(ConvolutionalBlock(3, 512));//10
+    large.template Add(PoolingBlock(2, 1, 0.5, 0.5));//11
+    large.template Add(ConvolutionalBlock(3, 1024));//12
+    large.template Add(ConvolutionalBlock(1, 256, 1, 0));//13
+    large.template Add(ConvolutionalBlock(3, 512));//14
+    large.template Add(ConvolutionalBlock(1, 255, 1, 0, false, false));//15
+    large.template Add(YOLOv3Block({3, 4, 5}));//16
 
-    for (auto layer : layers) {
-      model.template Add(layer);
-    }
-    //layers[17]= RouteBlock(13);
-    //layers[18]= ConvolutionalBlock(1, 128);
-    //layers[19]= UpsampleBlock(2);
-    //layers[20]= RouteBlock(19, 8);
-    //layers[21]= ConvolutionalBlock(3, 256);
-    //layers[21]= ConvolutionalBlock(3, 255);
-    //layers[23]= YOLOv3Block({0, 1, 2});
+    small.template Add(ConvolutionalBlock(3, 16));//0
+    small.template Add(PoolingBlock(2, 2));//1
+    small.template Add(ConvolutionalBlock(3, 32));//2
+    small.template Add(PoolingBlock(2, 2));//3
+    small.template Add(ConvolutionalBlock(3, 64));//4
+    small.template Add(PoolingBlock(2, 2));//5
+    small.template Add(ConvolutionalBlock(3, 128));//6
+    small.template Add(PoolingBlock(2, 2));//7
+
+    MultiLayer<MatType>* sequential = new MultiLayer<MatType>();
+    sequential->template Add(ConvolutionalBlock(3, 256));//8
+    sequential->template Add(PoolingBlock(2, 2));//9
+    sequential->template Add(ConvolutionalBlock(3, 512));//10
+    sequential->template Add(PoolingBlock(2, 1, 0.5, 0.5));//11
+    sequential->template Add(ConvolutionalBlock(3, 1024));//12
+    sequential->template Add(ConvolutionalBlock(1, 256, 1, 0));//13
+    sequential->template Add(ConvolutionalBlock(1, 128, 1, 0));//18
+    sequential->template Add(UpsampleBlock(2.0f));//19
+
+    MultiLayer<MatType>* layer8= new MultiLayer<MatType>();
+    layer8->template Add(ConvolutionalBlock(3, 256));//8
+
+    Concat* concatBlock = new Concat(2);
+    concatBlock->Add(sequential);
+    //concatBlock->Add(layer8);
+
+    small.template Add(concatBlock);//20
+    small.template Add(ConvolutionalBlock(3, 256));//21
+    small.template Add(ConvolutionalBlock(1, 255, 1, 0, false, false));//22
+    small.template Add(YOLOv3Block({0, 1, 2}));//23
+
+    large.Reset();
+    small.Reset();
   }
-
 
   ~YoloV3Tiny() {}
 
-  FFN<YoloV3TinyLoss<>, RandomInitialization>& Model() { return model; }
+  void Predict(const MatType& predictors,
+	       MatType& results,
+	       const size_t batchSize = 128) {
+    small.Predict(predictors, results, batchSize);
+    // large.Predict(predictors, ??, batchSize);//append small object detections with large object detections
+  }
+
+  //void Train();
+
+  void printModel() {
+
+    printf("Large object detections:\n");
+    for (size_t i = 0; i < large.Network().size(); i++) {
+      auto layer = large.Network()[i];
+      printLayer(layer, i);
+    }
+    printf("Small object detections:\n");
+    for (size_t i = 0; i < small.Network().size(); i++) {
+      auto layer = small.Network()[i];
+      printLayer(layer, i);
+    }
+  }
 
 private:
-  Layer<MatType>* PoolingBlock(const size_t kernel, const size_t stride, const double paddingW=0, const double paddingH=0) {
+  MultiLayer<MatType>* PoolingBlock(const size_t kernel, const size_t stride, const double paddingW=0, const double paddingH=0) {
     MultiLayer<MatType>* poolingBlock = new MultiLayer<MatType>();
     if (paddingW || paddingH)
       poolingBlock->template Add<Padding>(std::ceil(paddingW), std::floor(paddingW), std::ceil(paddingH), std::floor(paddingH));
@@ -79,7 +125,7 @@ private:
     return poolingBlock;
   }
 
-  Layer<MatType>* ConvolutionalBlock(const size_t kernelSize,
+  MultiLayer<MatType>* ConvolutionalBlock(const size_t kernelSize,
 			     const size_t filters,
 			     const size_t stride = 1,
 			     const size_t padding = 1,
@@ -96,15 +142,19 @@ private:
     return convBlock;
   }
 
-  Layer<MatType>* UpsampleBlock(const size_t scaleFactor) {}
-
-  Layer<MatType>* RouteBlock() {}
+  MultiLayer<MatType>* UpsampleBlock(const double scaleFactor) {
+    MultiLayer<MatType>* upsampleBlock = new MultiLayer<MatType>();
+    std::vector<double> scaleFactors = {scaleFactor, scaleFactor};
+    upsampleBlock->template Add<NearestInterpolation>(scaleFactors);
+    return upsampleBlock;
+  }
 
   Layer<MatType>* YOLOv3Block(const std::vector<size_t> mask) {
     return new mlpack::YOLOv3Layer<MatType>(mask, anchors);
   }
 
-  FFN<YoloV3TinyLoss<MatType>, RandomInitialization> model;
+  FFN<YoloV3TinyLoss<MatType>, RandomInitialization> large;
+  FFN<YoloV3TinyLoss<MatType>, RandomInitialization> small;
 
   size_t inputWidth;
   size_t inputHeight;
@@ -113,7 +163,13 @@ private:
 
   std::vector<double> anchors;
 
-  std::vector<Layer<MatType>*> layers;
+  void printLayer(mlpack::Layer<arma::mat>* layer, size_t layerIndex) {
+    int width = layer->OutputDimensions()[0];
+    int height = layer->OutputDimensions()[1];
+    int channels = layer->OutputDimensions()[2];
+    int batch = layer->OutputDimensions()[3];
+    printf("Layer %2d output shape:  %3d x %3d x %4d x %3d\n", (int)layerIndex, width, height, channels, batch);
+  }
 };
 
 } // namespace models

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -1,9 +1,7 @@
 #ifndef MODELS_MODELS_YOLOV3_TINY_YOLOV3_TINY_HPP
 #define MODELS_MODELS_YOLOV3_TINY_YOLOV3_TINY_HPP
 
-#include <mlpack/methods/ann/layer/adaptive_max_pooling.hpp>
-#include <mlpack/methods/ann/layer/add.hpp>
-#include <mlpack/methods/ann/layer/batch_norm.hpp>
+#include <mlpack/methods/ann/layer/convolution.hpp>
 #include <mlpack/methods/ann/layer/max_pooling.hpp>
 #include <mlpack/methods/ann/layer/multi_layer.hpp>
 
@@ -16,9 +14,14 @@ namespace models {
 template<typename MatType>
 class YoloV3Tiny {
 public:
+  /**
+  * 
+  */
   YoloV3Tiny(const size_t inputWidth,
 	     const size_t inputHeight,
 	     const size_t inputChannels,
+	     const std::vector<size_t> mask,
+	     const std::vector<double> anchors,
 	     const size_t numClasses = 80,
 	     const float ignoreThresh = 0.7
 	     ) :
@@ -27,30 +30,47 @@ public:
 	inputChannels(inputChannels),
 	numClasses(numClasses),
 	ignoreThresh(ignoreThresh)
+
 	{}
 
   ~YoloV3Tiny() {}
 
   void LoadModel(const std::string &filePath);
   void SaveModel(const std::string &filePath);
+  void Detect(const std::string& filePath);
 
 private:
-  MultiLayer<MatType>* MaxPoolBlock(const size_t size) {
+  Layer<MatType>* MaxPoolBlock(const size_t size) {
     return new MaxPooling(inputWidth / (double)size, inputHeight / (double)size);
   }
 
-  void Darknet19() {}
+  Layer<MatType>* ConvolutionalBlock(const size_t channels, 
+				     const size_t kernelSize, 
+				     const size_t filters, 
+				     const size_t stride) 
+  {
+    return new Convolution(channels, 
+			   kernelSize, 
+			   kernelSize, 
+			   stride, 
+			   stride);
+  }
+
+  void Darknet19();
+  void GetBox();
+  void NonMaxSuppression();
 
   size_t inputWidth;
   size_t inputHeight;
   size_t inputChannels;
   size_t numClasses;
   float ignoreThresh;
+
+  std::vector<size_t> mask;
+  std::vector<double> anchors;
 };
 
 } // namespace models
 } // namespace mlpack
-
-#include "yolov3_tiny_impl.hpp"
 
 #endif

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -23,178 +23,202 @@ namespace models {
 template<typename MatType>
 class YoloV3Tiny {
 public:
-  YoloV3Tiny(const std::vector<double> anchors,
+  YoloV3Tiny(
 	     const size_t inputWidth = 416,
 	     const size_t inputHeight = 416,
 	     const size_t inputChannels = 3,
 	     const size_t numClasses = 80
 	     ) :
-	anchors(anchors),
 	inputWidth(inputWidth),
 	inputHeight(inputHeight),
 	inputChannels(inputChannels),
 	numClasses(numClasses),
 	batchSize(1)
   {
+    large = new FFN<YoloV3TinyLoss<MatType>, RandomInitialization>();
     large->InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, batchSize});
-    small->InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, batchSize});
-   
+
+    //0
     large->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
-    large->template Add<BatchNorm>();
-    large->template Add<LeakyReLU>(0.1f);
+    large->template Add<BatchNorm>();//1
+    large->template Add<LeakyReLU>(0.1f);//2
 
-    large->template Add<MaxPooling>(2, 2, 2, 2);//1
-
-    large->template Add<Convolution>(32, 3, 3, 1, 1, 1, 1, "none", false);//2
-    large->template Add<BatchNorm>();
-    large->template Add<LeakyReLU>(0.1f);
-
+    //1
     large->template Add<MaxPooling>(2, 2, 2, 2);//3
-    
-    large->template Add<Convolution>(64, 3, 3, 1, 1, 1, 1, "none", false);//4
-    large->template Add<BatchNorm>();
-    large->template Add<LeakyReLU>(0.1f);
 
-    large->template Add<MaxPooling>(2, 2, 2, 2);//5
-    
-    large->template Add<Convolution>(128, 3, 3, 1, 1, 1, 1, "none", false);//6
-    large->template Add<BatchNorm>();
-    large->template Add<LeakyReLU>(0.1f);
-    
+    //2
+    large->template Add<Convolution>(32, 3, 3, 1, 1, 1, 1, "none", false);//4
+    large->template Add<BatchNorm>();//5
+    large->template Add<LeakyReLU>(0.1f);//6
+
+    //3
     large->template Add<MaxPooling>(2, 2, 2, 2);//7
-    
-    large->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//8
-    large->template Add<BatchNorm>();
-    large->template Add<LeakyReLU>(0.1f);
+   
+    //4
+    large->template Add<Convolution>(64, 3, 3, 1, 1, 1, 1, "none", false);//8
+    large->template Add<BatchNorm>();//9
+    large->template Add<LeakyReLU>(0.1f);//10
 
-    large->template Add<MaxPooling>(2, 2, 2, 2);//9
-    
-    large->template Add<Convolution>(512, 3, 3, 1, 1, 1, 1, "none", false);//10
-    large->template Add<BatchNorm>();
-    large->template Add<LeakyReLU>(0.1f);
+    //5
+    large->template Add<MaxPooling>(2, 2, 2, 2);//11
+   
+    //6
+    large->template Add<Convolution>(128, 3, 3, 1, 1, 1, 1, "none", false);//12
+    large->template Add<BatchNorm>();//13
+    large->template Add<LeakyReLU>(0.1f);//14
+   
+    //7
+    large->template Add<MaxPooling>(2, 2, 2, 2);//15
+   
+    //8
+    large->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//16
+    large->template Add<BatchNorm>();//17
+    large->template Add<LeakyReLU>(0.1f);//18
 
-    large->template Add<Padding>(1, 0, 1, 0);
-    large->template Add<MaxPooling>(2, 2, 1, 1);//11
-    
-    large->template Add<Convolution>(1024, 3, 3, 1, 1, 1, 1, "none", false);//12
-    large->template Add<BatchNorm>();
-    large->template Add<LeakyReLU>(0.1f);
+    //9
+    large->template Add<MaxPooling>(2, 2, 2, 2);//19
+   
+    //10
+    large->template Add<Convolution>(512, 3, 3, 1, 1, 1, 1, "none", false);//20
+    large->template Add<BatchNorm>();//21
+    large->template Add<LeakyReLU>(0.1f);//22
 
-    large->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//13
-    large->template Add<BatchNorm>();
-    large->template Add<LeakyReLU>(0.1f);
+    //11
+    large->template Add<Padding>(1, 0, 1, 0);//23
+    large->template Add<MaxPooling>(2, 2, 1, 1);//24
+   
+    //12
+    large->template Add<Convolution>(1024, 3, 3, 1, 1, 1, 1, "none", false);//25
+    large->template Add<BatchNorm>();//26
+    large->template Add<LeakyReLU>(0.1f);//27
 
-    large->template Add<Convolution>(512, 3, 3, 1, 1, 1, 1, "none", false);//14
-    large->template Add<BatchNorm>();
-    large->template Add<LeakyReLU>(0.1f);
+    //13
+    large->template Add<Convolution>(256, 1, 1, 1, 1, 0, 0, "none", false);//28
+    large->template Add<BatchNorm>();//29
+    large->template Add<LeakyReLU>(0.1f);//30
 
-    large->template Add<Convolution>(255, 1, 1, 1, 1, 1, 1, "none", true);//15
+    //14
+    large->template Add<Convolution>(512, 3, 3, 1, 1, 1, 1, "none", false);//31
+    large->template Add<BatchNorm>();//32
+    large->template Add<LeakyReLU>(0.1f);//33
 
-    large->template Add<YOLOv3Layer<MatType>>({3, 4, 5}, anchors);
+    //15
+    large->template Add<Convolution>(255, 1, 1, 1, 1, 0, 0, "none", true);//34
+
+    //16
+    std::vector<size_t> largeMask = {3, 4, 5};
+    large->template Add<YOLOv3Layer<MatType>>();//35
+    large->Reset();
 
     // Upsampled detections
-    MultiLayer<MatType>* layer19 = new MultiLayer<MatType>();
-    layer19->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
-    layer19->template Add<BatchNorm>();
-    layer19->template Add<LeakyReLU>(0.1f);
-    
-    layer19->template Add<MaxPooling>(2, 2, 2, 2);//1
-    
-    layer19->template Add<Convolution>(32, 3, 3, 1, 1, 1, 1, "none", false);//2
-    layer19->template Add<BatchNorm>();
-    layer19->template Add<LeakyReLU>(0.1f);
-   
-    layer19->template Add<MaxPooling>(2, 2, 2, 2);//3
-   
-    layer19->template Add<Convolution>(64, 3, 3, 1, 1, 1, 1, "none", false);//4
-    layer19->template Add<BatchNorm>();
-    layer19->template Add<LeakyReLU>(0.1f);
-   
-    layer19->template Add<MaxPooling>(2, 2, 2, 2);//5
-   
-    layer19->template Add<Convolution>(128, 3, 3, 1, 1, 1, 1, "none", false);//6
-    layer19->template Add<BatchNorm>();
-    layer19->template Add<LeakyReLU>(0.1f);
-   
-    layer19->template Add<MaxPooling>(2, 2, 2, 2);//7
-   
-    layer19->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//8
-    layer19->template Add<BatchNorm>();
-    layer19->template Add<LeakyReLU>(0.1f);
-
-    layer19->template Add<MaxPooling>(2, 2, 2, 2);//9
-
-    layer19->template Add<Convolution>(512, 3, 3, 1, 1, 1, 1, "none", false);//10
-    layer19->template Add<BatchNorm>();
-    layer19->template Add<LeakyReLU>(0.1f);
-
-    layer19->template Add<Padding>(1, 0, 1, 0);
-    layer19->template Add<MaxPooling>(2, 2, 1, 1);//11
-
-    layer19->template Add<Convolution>(1024, 3, 3, 1, 1, 1, 1, "none", false);//12
-    layer19->template Add<BatchNorm>();
-    layer19->template Add<LeakyReLU>(0.1f);
-
-    layer19->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//13
-    layer19->template Add<BatchNorm>();
-    layer19->template Add<LeakyReLU>(0.1f);
-
-    layer19->template Add<Convolution>(128, 1, 1, 1, 1, 0, 0, "none", false);//18
-    layer19->template Add<BatchNorm>();
-    layer19->template Add<LeakyReLU>(0.1f);
-
-    layer19->template Add<NearestInterpolation>({2.0f, 2.0f});
-    
-    //Layer8
-    MultiLayer<MatType>* layer8 = new MultiLayer<MatType>();
-    layer8->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
-    layer8->template Add<BatchNorm>();
-    layer8->template Add<LeakyReLU>(0.1f);
-    
-    layer8->template Add<MaxPooling>(2, 2, 2, 2);//1
-    
-    layer8->template Add<Convolution>(32, 3, 3, 1, 1, 1, 1, "none", false);//2
-    layer8->template Add<BatchNorm>();
-    layer8->template Add<LeakyReLU>(0.1f);
-   
-    layer8->template Add<MaxPooling>(2, 2, 2, 2);//3
-   
-    layer8->template Add<Convolution>(64, 3, 3, 1, 1, 1, 1, "none", false);//4
-    layer8->template Add<BatchNorm>();
-    layer8->template Add<LeakyReLU>(0.1f);
-   
-    layer8->template Add<MaxPooling>(2, 2, 2, 2);//5
-   
-    layer8->template Add<Convolution>(128, 3, 3, 1, 1, 1, 1, "none", false);//6
-    layer8->template Add<BatchNorm>();
-    layer8->template Add<LeakyReLU>(0.1f);
-   
-    layer8->template Add<MaxPooling>(2, 2, 2, 2);//7
-   
-    layer8->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//8
-    layer8->template Add<BatchNorm>();
-    layer8->template Add<LeakyReLU>(0.1f);
-
-    ConcatType<MatType>* layer20 = new ConcatType<MatType>();
-    layer20->template Add(layer19);
-    layer20->template Add(layer8);
-
-    small->template Add(layer20);
-
-    small->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//21
-    small->template Add<BatchNorm>();
-    small->template Add<LeakyReLU>(0.1f);
-
-    small->template Add<Convolution>(255, 1, 1, 1, 1, 0, 0, "none", true);//22
-
-    small->template Add<YOLOv3Layer<MatType>>({0, 1, 2}, anchors);
+    // small = new FFN...
+    //small->InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, batchSize});
+   //  MultiLayer<MatType>* layer19 = new MultiLayer<MatType>();
+   //  layer19->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
+   //  layer19->template Add<BatchNorm>();
+   //  layer19->template Add<LeakyReLU>(0.1f);
+   //  
+   //  layer19->template Add<MaxPooling>(2, 2, 2, 2);//1
+   //  
+   //  layer19->template Add<Convolution>(32, 3, 3, 1, 1, 1, 1, "none", false);//2
+   //  layer19->template Add<BatchNorm>();
+   //  layer19->template Add<LeakyReLU>(0.1f);
+   // 
+   //  layer19->template Add<MaxPooling>(2, 2, 2, 2);//3
+   // 
+   //  layer19->template Add<Convolution>(64, 3, 3, 1, 1, 1, 1, "none", false);//4
+   //  layer19->template Add<BatchNorm>();
+   //  layer19->template Add<LeakyReLU>(0.1f);
+   // 
+   //  layer19->template Add<MaxPooling>(2, 2, 2, 2);//5
+   // 
+   //  layer19->template Add<Convolution>(128, 3, 3, 1, 1, 1, 1, "none", false);//6
+   //  layer19->template Add<BatchNorm>();
+   //  layer19->template Add<LeakyReLU>(0.1f);
+   // 
+   //  layer19->template Add<MaxPooling>(2, 2, 2, 2);//7
+   // 
+   //  layer19->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//8
+   //  layer19->template Add<BatchNorm>();
+   //  layer19->template Add<LeakyReLU>(0.1f);
+   //
+   //  layer19->template Add<MaxPooling>(2, 2, 2, 2);//9
+   //
+   //  layer19->template Add<Convolution>(512, 3, 3, 1, 1, 1, 1, "none", false);//10
+   //  layer19->template Add<BatchNorm>();
+   //  layer19->template Add<LeakyReLU>(0.1f);
+   //
+   //  layer19->template Add<Padding>(1, 0, 1, 0);
+   //  layer19->template Add<MaxPooling>(2, 2, 1, 1);//11
+   //
+   //  layer19->template Add<Convolution>(1024, 3, 3, 1, 1, 1, 1, "none", false);//12
+   //  layer19->template Add<BatchNorm>();
+   //  layer19->template Add<LeakyReLU>(0.1f);
+   //
+   //  layer19->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//13
+   //  layer19->template Add<BatchNorm>();
+   //  layer19->template Add<LeakyReLU>(0.1f);
+   //
+   //  layer19->template Add<Convolution>(128, 1, 1, 1, 1, 0, 0, "none", false);//18
+   //  layer19->template Add<BatchNorm>();
+   //  layer19->template Add<LeakyReLU>(0.1f);
+   //
+   //  std::vector<double> scaleFactors = {2.0f, 2.0f};
+   //  layer19->template Add<NearestInterpolation>(scaleFactors);
+   //  
+   //  //Layer8
+   //  MultiLayer<MatType>* layer8 = new MultiLayer<MatType>();
+   //  layer8->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
+   //  layer8->template Add<BatchNorm>();
+   //  layer8->template Add<LeakyReLU>(0.1f);
+   //  
+   //  layer8->template Add<MaxPooling>(2, 2, 2, 2);//1
+   //  
+   //  layer8->template Add<Convolution>(32, 3, 3, 1, 1, 1, 1, "none", false);//2
+   //  layer8->template Add<BatchNorm>();
+   //  layer8->template Add<LeakyReLU>(0.1f);
+   // 
+   //  layer8->template Add<MaxPooling>(2, 2, 2, 2);//3
+   // 
+   //  layer8->template Add<Convolution>(64, 3, 3, 1, 1, 1, 1, "none", false);//4
+   //  layer8->template Add<BatchNorm>();
+   //  layer8->template Add<LeakyReLU>(0.1f);
+   // 
+   //  layer8->template Add<MaxPooling>(2, 2, 2, 2);//5
+   // 
+   //  layer8->template Add<Convolution>(128, 3, 3, 1, 1, 1, 1, "none", false);//6
+   //  layer8->template Add<BatchNorm>();
+   //  layer8->template Add<LeakyReLU>(0.1f);
+   // 
+   //  layer8->template Add<MaxPooling>(2, 2, 2, 2);//7
+   // 
+   //  layer8->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//8
+   //  layer8->template Add<BatchNorm>();
+   //  layer8->template Add<LeakyReLU>(0.1f);
+   //
+   //  ConcatType<MatType>* layer20 = new ConcatType<MatType>(2);
+   //  layer20->template Add(layer19);
+   //  layer20->template Add(layer8);
+   //
+   //  small->template Add(layer20);
+   //
+   //  small->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//21
+   //  small->template Add<BatchNorm>();
+   //  small->template Add<LeakyReLU>(0.1f);
+   //
+   //  small->template Add<Convolution>(255, 1, 1, 1, 1, 0, 0, "none", true);//22
+   //
+   //  std::vector<size_t> smallMask = {0, 1, 2};
+   //  small->template Add<YOLOv3Layer<MatType>>();
+   //
+   //  small->Reset();
   }
 
-  ~YoloV3Tiny() { delete large; delete small; }
+  ~YoloV3Tiny() { };
 
   void Predict(const MatType& predictors,
 	       MatType& results) {
-    large->Forward(predictors, results);
+    large->Predict(predictors, results);
   }
 
   void printModel() {
@@ -212,9 +236,9 @@ private:
     upsampleBlock->template Add<NearestInterpolation>(scaleFactors);
     return upsampleBlock;
   }
-
-  MultiLayer<MatType>* large = new MultiLayer<MatType>();
-  MultiLayer<MatType>* small = new MultiLayer<MatType>();
+  
+  FFN<YoloV3TinyLoss<MatType>, RandomInitialization>* large;
+  FFN<YoloV3TinyLoss<MatType>, RandomInitialization>* small;
 
   YoloV3TinyLoss<MatType> outputLayer;//for training only.
 
@@ -223,8 +247,6 @@ private:
   size_t inputChannels;
   size_t numClasses;
   size_t batchSize;
-
-  std::vector<double> anchors;
 
   void printLayer(mlpack::Layer<arma::mat>* layer, size_t layerIndex) {
     int width = layer->OutputDimensions()[0];

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -2,7 +2,6 @@
 #define MODELS_MODELS_YOLOV3_TINY_YOLOV3_TINY_HPP
 
 #include <mlpack/methods/ann/init_rules/random_init.hpp>
-#include <mlpack/methods/ann/layer/add.hpp>
 #include <mlpack/methods/ann/layer/batch_norm.hpp>
 #include <mlpack/methods/ann/layer/convolution.hpp>
 #include <mlpack/methods/ann/layer/leaky_relu.hpp>
@@ -38,7 +37,7 @@ public:
 	batchSize(1)
   {
     large->InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, batchSize});
-    //small.InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, 1});
+    small->InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, batchSize});
    
     large->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
     large->template Add<BatchNorm>();

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -80,7 +80,7 @@ public:
 
     Concat* concatBlock = new Concat(2);
     concatBlock->Add(sequential);
-    //concatBlock->Add(layer8);
+    concatBlock->Add(layer8);
 
     small.template Add(concatBlock);//20
     small.template Add(ConvolutionalBlock(3, 256));//21

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -33,46 +33,48 @@ public:
 	numClasses(numClasses)
   {
     AddConvolutionalBlock(3, 16);
-    AddPoolingBlock(2, 2);
-    AddConvolutionalBlock(3, 32);
-    AddPoolingBlock(2, 2);
-    AddConvolutionalBlock(3, 64);
-    AddPoolingBlock(2, 2);
-    AddConvolutionalBlock(3, 128);
-    AddPoolingBlock(2, 2);
-    AddConvolutionalBlock(3, 256);//save
-    AddPoolingBlock(2, 2);
-    AddConvolutionalBlock(3, 512);
-    AddPoolingBlock(2, 2);
-    AddConvolutionalBlock(3, 1024);
-    AddConvolutionalBlock(1, 256);//save
-    AddConvolutionalBlock(3, 512);
-    AddConvolutionalBlock(1, 255);
-    model.Add(mlpack::YoloLayer<arma::mat>);
+    // AddPoolingBlock(2, 2);
+    // AddConvolutionalBlock(3, 32);
+    // AddPoolingBlock(2, 2);
+    // AddConvolutionalBlock(3, 64);
+    // AddPoolingBlock(2, 2);
+    // AddConvolutionalBlock(3, 128);
+    // AddPoolingBlock(2, 2);
+    // AddConvolutionalBlock(3, 256);//save
+    // AddPoolingBlock(2, 2);
+    // AddConvolutionalBlock(3, 512);
+    // AddPoolingBlock(2, 2);
+    // AddConvolutionalBlock(3, 1024);
+    // AddConvolutionalBlock(1, 256);//save
+    // AddConvolutionalBlock(3, 512);
+    // AddConvolutionalBlock(1, 255);
+    // model.Add(mlpack::YoloLayer<arma::mat>);
 
   }
 
   ~YoloV3Tiny() {}
 
 private:
-  void AddPoolingBlock(const size_t kernel, const size_t stride) {
-    model.Add(MaxPooling(kernel, kernel, stride, stride));
+  Layer<MatType>* AddPoolingBlock(const size_t kernel, const size_t stride) {
+    return new MaxPooling(kernel, kernel, stride, stride);
   }
 
-  void AddConvolutionalBlock(const size_t kernelSize,
+  Layer<MatType>* AddConvolutionalBlock(const size_t kernelSize,
 			     const size_t filters,
 			     const size_t stride = 1,
 			     const size_t padding = 1,
 			     const bool batchNorm = true,
 			     const bool activate = true) {
-    model.Add(Convolution(filters, kernelSize, kernelSize, stride, stride, padding, padding, "none", false));
+    MultiLayer<MatType>* convBlock = new MultiLayer<MatType>();
+    convBlock->Add(Convolution(filters, kernelSize, kernelSize, stride, stride, padding, padding, "none", false));
     if (batchNorm) {
-      model.Add(BatchNorm());
+      convBlock->Add(BatchNorm());
     }
-    model.Add(Add());//biases
+    // TODO: bias
     if (activate) {
-      model.Add(LeakyReLU(0.1));
+      convBlock->Add(LeakyReLU(0.1));
     }
+    return convBlock;
   }
 
   FFN<YoloV3TinyLoss<MatType>, RandomInitialization> model;

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -1,9 +1,13 @@
 #ifndef MODELS_MODELS_YOLOV3_TINY_YOLOV3_TINY_HPP
 #define MODELS_MODELS_YOLOV3_TINY_YOLOV3_TINY_HPP
 
+#include <mlpack/methods/ann/init_rules/random_init.hpp>
 #include <mlpack/methods/ann/layer/convolution.hpp>
 #include <mlpack/methods/ann/layer/max_pooling.hpp>
 #include <mlpack/methods/ann/layer/multi_layer.hpp>
+
+#include "yolov3_tiny_loss.hpp"
+#include "yolov3_tiny_layer.hpp"
 
 #define MLPACK_ENABLE_ANN_SERIALIZATION
 #include <mlpack.hpp>
@@ -14,11 +18,11 @@ namespace models {
 template<typename MatType>
 class YoloV3Tiny {
 public:
-  YoloV3Tiny(const size_t inputWidth,
-	     const size_t inputHeight,
-	     const size_t inputChannels,
-	     const std::vector<size_t> mask,
+  YoloV3Tiny(const std::vector<size_t> mask,
 	     const std::vector<double> anchors,
+	     const size_t inputWidth = 416,
+	     const size_t inputHeight = 416,
+	     const size_t inputChannels = 3,
 	     const size_t numClasses = 80
 	     ) :
 	inputWidth(inputWidth),
@@ -29,15 +33,12 @@ public:
 
   ~YoloV3Tiny() {}
 
-  void LoadModel(const std::string &filePath) {}
-  void SaveModel(const std::string &filePath) {}
-
 private:
-  Layer<MatType>* MaxPoolBlock(const size_t size) {
-    return new MaxPooling(inputWidth / (double)size, inputHeight / (double)size);
+  void AddPoolingBlock(const size_t kernel, const size_t stride) {
+    model.Add(MaxPooling(kernel, kernel, stride, stride));
   }
 
-  FFN<> model;
+  FFN<YoloV3TinyLoss<MatType>, RandomInitialization> model;
 
   size_t inputWidth;
   size_t inputHeight;

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -2,7 +2,10 @@
 #define MODELS_MODELS_YOLOV3_TINY_YOLOV3_TINY_HPP
 
 #include <mlpack/methods/ann/init_rules/random_init.hpp>
+#include <mlpack/methods/ann/layer/add.hpp>
+#include <mlpack/methods/ann/layer/batch_norm.hpp>
 #include <mlpack/methods/ann/layer/convolution.hpp>
+#include <mlpack/methods/ann/layer/leaky_relu.hpp>
 #include <mlpack/methods/ann/layer/max_pooling.hpp>
 #include <mlpack/methods/ann/layer/multi_layer.hpp>
 
@@ -18,8 +21,7 @@ namespace models {
 template<typename MatType>
 class YoloV3Tiny {
 public:
-  YoloV3Tiny(const std::vector<size_t> mask,
-	     const std::vector<double> anchors,
+  YoloV3Tiny(const std::vector<double> anchors,
 	     const size_t inputWidth = 416,
 	     const size_t inputHeight = 416,
 	     const size_t inputChannels = 3,
@@ -29,13 +31,48 @@ public:
 	inputHeight(inputHeight),
 	inputChannels(inputChannels),
 	numClasses(numClasses)
-	{}
+  {
+    AddConvolutionalBlock(3, 16);
+    AddPoolingBlock(2, 2);
+    AddConvolutionalBlock(3, 32);
+    AddPoolingBlock(2, 2);
+    AddConvolutionalBlock(3, 64);
+    AddPoolingBlock(2, 2);
+    AddConvolutionalBlock(3, 128);
+    AddPoolingBlock(2, 2);
+    AddConvolutionalBlock(3, 256);//save
+    AddPoolingBlock(2, 2);
+    AddConvolutionalBlock(3, 512);
+    AddPoolingBlock(2, 2);
+    AddConvolutionalBlock(3, 1024);
+    AddConvolutionalBlock(1, 256);//save
+    AddConvolutionalBlock(3, 512);
+    AddConvolutionalBlock(1, 255);
+    model.Add(mlpack::YoloLayer<arma::mat>);
+
+  }
 
   ~YoloV3Tiny() {}
 
 private:
   void AddPoolingBlock(const size_t kernel, const size_t stride) {
     model.Add(MaxPooling(kernel, kernel, stride, stride));
+  }
+
+  void AddConvolutionalBlock(const size_t kernelSize,
+			     const size_t filters,
+			     const size_t stride = 1,
+			     const size_t padding = 1,
+			     const bool batchNorm = true,
+			     const bool activate = true) {
+    model.Add(Convolution(filters, kernelSize, kernelSize, stride, stride, padding, padding, "none", false));
+    if (batchNorm) {
+      model.Add(BatchNorm());
+    }
+    model.Add(Add());//biases
+    if (activate) {
+      model.Add(LeakyReLU(0.1));
+    }
   }
 
   FFN<YoloV3TinyLoss<MatType>, RandomInitialization> model;
@@ -45,7 +82,6 @@ private:
   size_t inputChannels;
   size_t numClasses;
 
-  std::vector<size_t> mask;
   std::vector<double> anchors;
 };
 

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -114,7 +114,7 @@ public:
     large->Reset();
 
     // Upsampled detections
-    small = new FFN<YoloV3TinyLoss<MatType>, RandomInitialization>();
+    small = new FFN<YoloV3TinyLoss<MatType>, RandomInitialization>(YoloV3TinyLoss<MatType>(26, 26));
     small->InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, batchSize});
 
     MultiLayer<MatType>* layer19 = new MultiLayer<MatType>();
@@ -273,7 +273,8 @@ private:
   FFN<YoloV3TinyLoss<MatType>, RandomInitialization>* large;
   FFN<YoloV3TinyLoss<MatType>, RandomInitialization>* small;
 
-  YoloV3TinyLoss<MatType> outputLayer;//for training only.
+  YoloV3TinyLoss<MatType> largeLoss;//13x13
+  YoloV3TinyLoss<MatType> smallLoss;//26x26
 
   size_t inputWidth;
   size_t inputHeight;

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -14,57 +14,35 @@ namespace models {
 template<typename MatType>
 class YoloV3Tiny {
 public:
-  /**
-  * 
-  */
   YoloV3Tiny(const size_t inputWidth,
 	     const size_t inputHeight,
 	     const size_t inputChannels,
 	     const std::vector<size_t> mask,
 	     const std::vector<double> anchors,
-	     const size_t numClasses = 80,
-	     const float ignoreThresh = 0.7
+	     const size_t numClasses = 80
 	     ) :
 	inputWidth(inputWidth),
 	inputHeight(inputHeight),
 	inputChannels(inputChannels),
-	numClasses(numClasses),
-	ignoreThresh(ignoreThresh)
-
+	numClasses(numClasses)
 	{}
 
   ~YoloV3Tiny() {}
 
-  void LoadModel(const std::string &filePath);
-  void SaveModel(const std::string &filePath);
-  void Detect(const std::string& filePath);
+  void LoadModel(const std::string &filePath) {}
+  void SaveModel(const std::string &filePath) {}
 
 private:
   Layer<MatType>* MaxPoolBlock(const size_t size) {
     return new MaxPooling(inputWidth / (double)size, inputHeight / (double)size);
   }
 
-  Layer<MatType>* ConvolutionalBlock(const size_t channels, 
-				     const size_t kernelSize, 
-				     const size_t filters, 
-				     const size_t stride) 
-  {
-    return new Convolution(channels, 
-			   kernelSize, 
-			   kernelSize, 
-			   stride, 
-			   stride);
-  }
-
-  void Darknet19();
-  void GetBox();
-  void NonMaxSuppression();
+  FFN<> model;
 
   size_t inputWidth;
   size_t inputHeight;
   size_t inputChannels;
   size_t numClasses;
-  float ignoreThresh;
 
   std::vector<size_t> mask;
   std::vector<double> anchors;

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -33,10 +33,11 @@ public:
 	inputWidth(inputWidth),
 	inputHeight(inputHeight),
 	inputChannels(inputChannels),
-	numClasses(numClasses)
+	numClasses(numClasses),
+	batchSize(1)
   {
-    large->InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, 1});
-    // small.InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, 1});
+    large->InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, batchSize});
+    //small.InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, 1});
    
     large->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
     large->template Add<BatchNorm>();
@@ -91,15 +92,35 @@ public:
 
     large->template Add<YOLOv3Layer<MatType>>({3, 4, 5}, anchors);
 
-    // small.template Add(ConvolutionalBlock(3, 16));//0
-    // small.template Add(PoolingBlock(2, 2));//1
-    // small.template Add(ConvolutionalBlock(3, 32));//2
-    // small.template Add(PoolingBlock(2, 2));//3
-    // small.template Add(ConvolutionalBlock(3, 64));//4
-    // small.template Add(PoolingBlock(2, 2));//5
-    // small.template Add(ConvolutionalBlock(3, 128));//6
-    // small.template Add(PoolingBlock(2, 2));//7
+
+    // small->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
+    // small->template Add<BatchNorm>();
+    // small->template Add<LeakyReLU>(0.1f);
     //
+    // small->template Add<MaxPooling>(2, 2, 2, 2);//1
+    //
+    // small->template Add<Convolution>(32, 3, 3, 1, 1, 1, 1, "none", false);//2
+    // small->template Add<BatchNorm>();
+    // small->template Add<LeakyReLU>(0.1f);
+    //
+    // small->template Add<MaxPooling>(2, 2, 2, 2);//3
+    // 
+    // small->template Add<Convolution>(64, 3, 3, 1, 1, 1, 1, "none", false);//4
+    // small->template Add<BatchNorm>();
+    // small->template Add<LeakyReLU>(0.1f);
+    //
+    // small->template Add<MaxPooling>(2, 2, 2, 2);//5
+    //
+    // small->template Add<Convolution>(128, 3, 3, 1, 1, 1, 1, "none", false);//6
+    // small->template Add<BatchNorm>();
+    // small->template Add<LeakyReLU>(0.1f);
+    //
+    // small->template Add<MaxPooling>(2, 2, 2, 2);//7
+    // 
+    // small->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//8
+    // small->template Add<BatchNorm>();
+    // small->template Add<LeakyReLU>(0.1f);
+    // 
     // MultiLayer<MatType>* sequential = new MultiLayer<MatType>();
     // sequential->template Add(ConvolutionalBlock(3, 256));//8
     // sequential->template Add(PoolingBlock(2, 2));//9
@@ -109,24 +130,21 @@ public:
     // sequential->template Add(ConvolutionalBlock(1, 256, 1, 0));//13
     // sequential->template Add(ConvolutionalBlock(1, 128, 1, 0));//18
     // sequential->template Add(UpsampleBlock(2.0f));//19
-    //
+    // 
     // MultiLayer<MatType>* layer8= new MultiLayer<MatType>();
     // layer8->template Add(ConvolutionalBlock(3, 256));//8
-    //
+    // 
     // Concat* concatBlock = new Concat(2);
     // concatBlock->Add(sequential);
     // concatBlock->Add(layer8);
-    //
+    // 
     // small.template Add(concatBlock);//20
     // small.template Add(ConvolutionalBlock(3, 256));//21
     // small.template Add(ConvolutionalBlock(1, 255, 1, 0, false, false));//22
     // small.template Add(YOLOv3Block({0, 1, 2}));//23
-    //
-    // small.Reset();
-    // large.Reset();
   }
 
-  ~YoloV3Tiny() { delete large; }
+  ~YoloV3Tiny() { delete large; delete small; }
 
   void Predict(const MatType& predictors,
 	       MatType& results) {
@@ -150,14 +168,15 @@ private:
   }
 
   MultiLayer<MatType>* large = new MultiLayer<MatType>();
-  // MultiLayer<MatType>* small = new MultiLayer<MatType>();
+  MultiLayer<MatType>* small = new MultiLayer<MatType>();
 
-  YoloV3TinyLoss<MatType> outputLayer;
+  YoloV3TinyLoss<MatType> outputLayer;//for training only.
 
   size_t inputWidth;
   size_t inputHeight;
   size_t inputChannels;
   size_t numClasses;
+  size_t batchSize;
 
   std::vector<double> anchors;
 

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -27,13 +27,14 @@ public:
 	     const size_t inputWidth = 416,
 	     const size_t inputHeight = 416,
 	     const size_t inputChannels = 3,
-	     const size_t numClasses = 80
+	     const size_t numClasses = 80,
+	     const size_t batchSize = 1
 	     ) :
 	inputWidth(inputWidth),
 	inputHeight(inputHeight),
 	inputChannels(inputChannels),
 	numClasses(numClasses),
-	batchSize(1)
+	batchSize(batchSize)
   {
     large = new FFN<YoloV3TinyLoss<MatType>, RandomInitialization>();
     large->InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, batchSize});
@@ -106,125 +107,156 @@ public:
     large->template Add<Convolution>(255, 1, 1, 1, 1, 0, 0, "none", true);//34
 
     //16
-    std::vector<size_t> largeMask = {3, 4, 5};
     large->template Add<YOLOv3Layer<MatType>>();//35
     large->Reset();
 
     // Upsampled detections
-    // small = new FFN...
-    //small->InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, batchSize});
-   //  MultiLayer<MatType>* layer19 = new MultiLayer<MatType>();
-   //  layer19->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
-   //  layer19->template Add<BatchNorm>();
-   //  layer19->template Add<LeakyReLU>(0.1f);
-   //  
-   //  layer19->template Add<MaxPooling>(2, 2, 2, 2);//1
-   //  
-   //  layer19->template Add<Convolution>(32, 3, 3, 1, 1, 1, 1, "none", false);//2
-   //  layer19->template Add<BatchNorm>();
-   //  layer19->template Add<LeakyReLU>(0.1f);
-   // 
-   //  layer19->template Add<MaxPooling>(2, 2, 2, 2);//3
-   // 
-   //  layer19->template Add<Convolution>(64, 3, 3, 1, 1, 1, 1, "none", false);//4
-   //  layer19->template Add<BatchNorm>();
-   //  layer19->template Add<LeakyReLU>(0.1f);
-   // 
-   //  layer19->template Add<MaxPooling>(2, 2, 2, 2);//5
-   // 
-   //  layer19->template Add<Convolution>(128, 3, 3, 1, 1, 1, 1, "none", false);//6
-   //  layer19->template Add<BatchNorm>();
-   //  layer19->template Add<LeakyReLU>(0.1f);
-   // 
-   //  layer19->template Add<MaxPooling>(2, 2, 2, 2);//7
-   // 
-   //  layer19->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//8
-   //  layer19->template Add<BatchNorm>();
-   //  layer19->template Add<LeakyReLU>(0.1f);
-   //
-   //  layer19->template Add<MaxPooling>(2, 2, 2, 2);//9
-   //
-   //  layer19->template Add<Convolution>(512, 3, 3, 1, 1, 1, 1, "none", false);//10
-   //  layer19->template Add<BatchNorm>();
-   //  layer19->template Add<LeakyReLU>(0.1f);
-   //
-   //  layer19->template Add<Padding>(1, 0, 1, 0);
-   //  layer19->template Add<MaxPooling>(2, 2, 1, 1);//11
-   //
-   //  layer19->template Add<Convolution>(1024, 3, 3, 1, 1, 1, 1, "none", false);//12
-   //  layer19->template Add<BatchNorm>();
-   //  layer19->template Add<LeakyReLU>(0.1f);
-   //
-   //  layer19->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//13
-   //  layer19->template Add<BatchNorm>();
-   //  layer19->template Add<LeakyReLU>(0.1f);
-   //
-   //  layer19->template Add<Convolution>(128, 1, 1, 1, 1, 0, 0, "none", false);//18
-   //  layer19->template Add<BatchNorm>();
-   //  layer19->template Add<LeakyReLU>(0.1f);
-   //
-   //  std::vector<double> scaleFactors = {2.0f, 2.0f};
-   //  layer19->template Add<NearestInterpolation>(scaleFactors);
-   //  
-   //  //Layer8
-   //  MultiLayer<MatType>* layer8 = new MultiLayer<MatType>();
-   //  layer8->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
-   //  layer8->template Add<BatchNorm>();
-   //  layer8->template Add<LeakyReLU>(0.1f);
-   //  
-   //  layer8->template Add<MaxPooling>(2, 2, 2, 2);//1
-   //  
-   //  layer8->template Add<Convolution>(32, 3, 3, 1, 1, 1, 1, "none", false);//2
-   //  layer8->template Add<BatchNorm>();
-   //  layer8->template Add<LeakyReLU>(0.1f);
-   // 
-   //  layer8->template Add<MaxPooling>(2, 2, 2, 2);//3
-   // 
-   //  layer8->template Add<Convolution>(64, 3, 3, 1, 1, 1, 1, "none", false);//4
-   //  layer8->template Add<BatchNorm>();
-   //  layer8->template Add<LeakyReLU>(0.1f);
-   // 
-   //  layer8->template Add<MaxPooling>(2, 2, 2, 2);//5
-   // 
-   //  layer8->template Add<Convolution>(128, 3, 3, 1, 1, 1, 1, "none", false);//6
-   //  layer8->template Add<BatchNorm>();
-   //  layer8->template Add<LeakyReLU>(0.1f);
-   // 
-   //  layer8->template Add<MaxPooling>(2, 2, 2, 2);//7
-   // 
-   //  layer8->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//8
-   //  layer8->template Add<BatchNorm>();
-   //  layer8->template Add<LeakyReLU>(0.1f);
-   //
-   //  ConcatType<MatType>* layer20 = new ConcatType<MatType>(2);
-   //  layer20->template Add(layer19);
-   //  layer20->template Add(layer8);
-   //
-   //  small->template Add(layer20);
-   //
-   //  small->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//21
-   //  small->template Add<BatchNorm>();
-   //  small->template Add<LeakyReLU>(0.1f);
-   //
-   //  small->template Add<Convolution>(255, 1, 1, 1, 1, 0, 0, "none", true);//22
-   //
-   //  std::vector<size_t> smallMask = {0, 1, 2};
-   //  small->template Add<YOLOv3Layer<MatType>>();
-   //
-   //  small->Reset();
+    small = new FFN<YoloV3TinyLoss<MatType>, RandomInitialization>();
+    small->InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, batchSize});
+
+    MultiLayer<MatType>* layer19 = new MultiLayer<MatType>();
+
+    //0
+    layer19->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
+    layer19->template Add<BatchNorm>();//1
+    layer19->template Add<LeakyReLU>(0.1f);//2
+   
+    //1
+    layer19->template Add<MaxPooling>(2, 2, 2, 2);//3
+   
+    //2
+    layer19->template Add<Convolution>(32, 3, 3, 1, 1, 1, 1, "none", false);//3
+    layer19->template Add<BatchNorm>();//4
+    layer19->template Add<LeakyReLU>(0.1f);//5
+
+    //3
+    layer19->template Add<MaxPooling>(2, 2, 2, 2);//6
+
+    //4
+    layer19->template Add<Convolution>(64, 3, 3, 1, 1, 1, 1, "none", false);//7
+    layer19->template Add<BatchNorm>();//8
+    layer19->template Add<LeakyReLU>(0.1f);//9
+
+    //5
+    layer19->template Add<MaxPooling>(2, 2, 2, 2);//10
+
+    //6
+    layer19->template Add<Convolution>(128, 3, 3, 1, 1, 1, 1, "none", false);//11
+    layer19->template Add<BatchNorm>();//12
+    layer19->template Add<LeakyReLU>(0.1f);//13
+
+    //7
+    layer19->template Add<MaxPooling>(2, 2, 2, 2);//14
+
+    //8
+    layer19->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//15
+    layer19->template Add<BatchNorm>();//16
+    layer19->template Add<LeakyReLU>(0.1f);//17
+
+    //9
+    layer19->template Add<MaxPooling>(2, 2, 2, 2);//18
+
+    //10
+    layer19->template Add<Convolution>(512, 3, 3, 1, 1, 1, 1, "none", false);//19
+    layer19->template Add<BatchNorm>();//20
+    layer19->template Add<LeakyReLU>(0.1f);//21
+
+    //11
+    layer19->template Add<Padding>(1, 0, 1, 0);//22
+    layer19->template Add<MaxPooling>(2, 2, 1, 1);//23
+
+    //12
+    layer19->template Add<Convolution>(1024, 3, 3, 1, 1, 1, 1, "none", false);//24
+    layer19->template Add<BatchNorm>();//25
+    layer19->template Add<LeakyReLU>(0.1f);//26
+
+    //13
+    layer19->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//27
+    layer19->template Add<BatchNorm>();//28
+    layer19->template Add<LeakyReLU>(0.1f);//29
+
+    //18
+    layer19->template Add<Convolution>(128, 1, 1, 1, 1, 0, 0, "none", false);//30
+    layer19->template Add<BatchNorm>();//31
+    layer19->template Add<LeakyReLU>(0.1f);//32
+
+    //19
+    std::vector<double> scaleFactors = {2.0f, 2.0f};
+    layer19->template Add<NearestInterpolation>(scaleFactors);
+    
+    //Layer8
+    MultiLayer<MatType>* layer8 = new MultiLayer<MatType>();
+    //0
+    layer8->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
+    layer8->template Add<BatchNorm>();//1
+    layer8->template Add<LeakyReLU>(0.1f);//2
+   
+    //1
+    layer8->template Add<MaxPooling>(2, 2, 2, 2);//3
+   
+    //2
+    layer8->template Add<Convolution>(32, 3, 3, 1, 1, 1, 1, "none", false);//3
+    layer8->template Add<BatchNorm>();//4
+    layer8->template Add<LeakyReLU>(0.1f);//5
+
+    //3
+    layer8->template Add<MaxPooling>(2, 2, 2, 2);//6
+
+    //4
+    layer8->template Add<Convolution>(64, 3, 3, 1, 1, 1, 1, "none", false);//7
+    layer8->template Add<BatchNorm>();//8
+    layer8->template Add<LeakyReLU>(0.1f);//9
+
+    //5
+    layer8->template Add<MaxPooling>(2, 2, 2, 2);//10
+
+    //6
+    layer8->template Add<Convolution>(128, 3, 3, 1, 1, 1, 1, "none", false);//11
+    layer8->template Add<BatchNorm>();//12
+    layer8->template Add<LeakyReLU>(0.1f);//13
+
+    //7
+    layer8->template Add<MaxPooling>(2, 2, 2, 2);//14
+
+    //8
+    layer8->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//15
+    layer8->template Add<BatchNorm>();//16
+    layer8->template Add<LeakyReLU>(0.1f);//17
+
+    ConcatType<MatType>* layer20 = new ConcatType<MatType>(2);
+    layer20->template Add(layer19);
+    layer20->template Add(layer8);
+
+    small->template Add(layer20);
+
+    small->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//21
+    small->template Add<BatchNorm>();
+    small->template Add<LeakyReLU>(0.1f);
+
+    small->template Add<Convolution>(255, 1, 1, 1, 1, 0, 0, "none", true);//22
+
+    small->template Add<YOLOv3Layer<MatType>>();
+    small->Reset();
   }
 
   ~YoloV3Tiny() { };
 
   void Predict(const MatType& predictors,
-	       MatType& results) {
-    large->Predict(predictors, results);
+	       MatType& largeObjects,
+	       MatType& smallObjects) {
+    large->Predict(predictors, largeObjects);
+    small->Predict(predictors, smallObjects);
   }
 
   void printModel() {
     printf("Large object detections:\n");
     for (size_t i = 0; i < large->Network().size(); i++) {
       auto layer = large->Network()[i];
+      printLayer(layer, i);
+    }
+    printf("Small object detections:\n");
+    for (size_t i = 0; i < small->Network().size(); i++) {
+      auto layer = small->Network()[i];
       printLayer(layer, i);
     }
   }

--- a/models/yolov3_tiny/yolov3_tiny.hpp
+++ b/models/yolov3_tiny/yolov3_tiny.hpp
@@ -35,113 +35,113 @@ public:
 	inputChannels(inputChannels),
 	numClasses(numClasses)
   {
-    large.InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, 1});
-    small.InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, 1});
+    large->InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, 1});
+    // small.InputDimensions() = std::vector<size_t>({inputWidth, inputHeight, inputChannels, 1});
+   
+    large->template Add<Convolution>(16, 3, 3, 1, 1, 1, 1, "none", false);//0
+    large->template Add<BatchNorm>();
+    large->template Add<LeakyReLU>(0.1f);
+
+    large->template Add<MaxPooling>(2, 2, 2, 2);//1
+
+    large->template Add<Convolution>(32, 3, 3, 1, 1, 1, 1, "none", false);//2
+    large->template Add<BatchNorm>();
+    large->template Add<LeakyReLU>(0.1f);
+
+    large->template Add<MaxPooling>(2, 2, 2, 2);//3
     
-    large.template Add(ConvolutionalBlock(3, 16));//0
-    large.template Add(PoolingBlock(2, 2));//1
-    large.template Add(ConvolutionalBlock(3, 32));//2
-    large.template Add(PoolingBlock(2, 2));//3
-    large.template Add(ConvolutionalBlock(3, 64));//4
-    large.template Add(PoolingBlock(2, 2));//5
-    large.template Add(ConvolutionalBlock(3, 128));//6
-    large.template Add(PoolingBlock(2, 2));//7
-    large.template Add(ConvolutionalBlock(3, 256));//8
-    large.template Add(PoolingBlock(2, 2));//9
-    large.template Add(ConvolutionalBlock(3, 512));//10
-    large.template Add(PoolingBlock(2, 1, 0.5, 0.5));//11
-    large.template Add(ConvolutionalBlock(3, 1024));//12
-    large.template Add(ConvolutionalBlock(1, 256, 1, 0));//13
-    large.template Add(ConvolutionalBlock(3, 512));//14
-    large.template Add(ConvolutionalBlock(1, 255, 1, 0, false, false));//15
-    large.template Add(YOLOv3Block({3, 4, 5}));//16
+    large->template Add<Convolution>(64, 3, 3, 1, 1, 1, 1, "none", false);//4
+    large->template Add<BatchNorm>();
+    large->template Add<LeakyReLU>(0.1f);
 
-    small.template Add(ConvolutionalBlock(3, 16));//0
-    small.template Add(PoolingBlock(2, 2));//1
-    small.template Add(ConvolutionalBlock(3, 32));//2
-    small.template Add(PoolingBlock(2, 2));//3
-    small.template Add(ConvolutionalBlock(3, 64));//4
-    small.template Add(PoolingBlock(2, 2));//5
-    small.template Add(ConvolutionalBlock(3, 128));//6
-    small.template Add(PoolingBlock(2, 2));//7
+    large->template Add<MaxPooling>(2, 2, 2, 2);//5
+    
+    large->template Add<Convolution>(128, 3, 3, 1, 1, 1, 1, "none", false);//6
+    large->template Add<BatchNorm>();
+    large->template Add<LeakyReLU>(0.1f);
+    
+    large->template Add<MaxPooling>(2, 2, 2, 2);//7
+    
+    large->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//8
+    large->template Add<BatchNorm>();
+    large->template Add<LeakyReLU>(0.1f);
 
-    MultiLayer<MatType>* sequential = new MultiLayer<MatType>();
-    sequential->template Add(ConvolutionalBlock(3, 256));//8
-    sequential->template Add(PoolingBlock(2, 2));//9
-    sequential->template Add(ConvolutionalBlock(3, 512));//10
-    sequential->template Add(PoolingBlock(2, 1, 0.5, 0.5));//11
-    sequential->template Add(ConvolutionalBlock(3, 1024));//12
-    sequential->template Add(ConvolutionalBlock(1, 256, 1, 0));//13
-    sequential->template Add(ConvolutionalBlock(1, 128, 1, 0));//18
-    sequential->template Add(UpsampleBlock(2.0f));//19
+    large->template Add<MaxPooling>(2, 2, 2, 2);//9
+    
+    large->template Add<Convolution>(512, 3, 3, 1, 1, 1, 1, "none", false);//10
+    large->template Add<BatchNorm>();
+    large->template Add<LeakyReLU>(0.1f);
 
-    MultiLayer<MatType>* layer8= new MultiLayer<MatType>();
-    layer8->template Add(ConvolutionalBlock(3, 256));//8
+    large->template Add<Padding>(1, 0, 1, 0);
+    large->template Add<MaxPooling>(2, 2, 1, 1);//11
+    
+    large->template Add<Convolution>(1024, 3, 3, 1, 1, 1, 1, "none", false);//12
+    large->template Add<BatchNorm>();
+    large->template Add<LeakyReLU>(0.1f);
 
-    Concat* concatBlock = new Concat(2);
-    concatBlock->Add(sequential);
-    concatBlock->Add(layer8);
+    large->template Add<Convolution>(256, 3, 3, 1, 1, 1, 1, "none", false);//13
+    large->template Add<BatchNorm>();
+    large->template Add<LeakyReLU>(0.1f);
 
-    small.template Add(concatBlock);//20
-    small.template Add(ConvolutionalBlock(3, 256));//21
-    small.template Add(ConvolutionalBlock(1, 255, 1, 0, false, false));//22
-    small.template Add(YOLOv3Block({0, 1, 2}));//23
+    large->template Add<Convolution>(512, 3, 3, 1, 1, 1, 1, "none", false);//14
+    large->template Add<BatchNorm>();
+    large->template Add<LeakyReLU>(0.1f);
 
-    large.Reset();
-    small.Reset();
+    large->template Add<Convolution>(255, 1, 1, 1, 1, 1, 1, "none", true);//15
+
+    large->template Add<YOLOv3Layer<MatType>>({3, 4, 5}, anchors);
+
+    // small.template Add(ConvolutionalBlock(3, 16));//0
+    // small.template Add(PoolingBlock(2, 2));//1
+    // small.template Add(ConvolutionalBlock(3, 32));//2
+    // small.template Add(PoolingBlock(2, 2));//3
+    // small.template Add(ConvolutionalBlock(3, 64));//4
+    // small.template Add(PoolingBlock(2, 2));//5
+    // small.template Add(ConvolutionalBlock(3, 128));//6
+    // small.template Add(PoolingBlock(2, 2));//7
+    //
+    // MultiLayer<MatType>* sequential = new MultiLayer<MatType>();
+    // sequential->template Add(ConvolutionalBlock(3, 256));//8
+    // sequential->template Add(PoolingBlock(2, 2));//9
+    // sequential->template Add(ConvolutionalBlock(3, 512));//10
+    // sequential->template Add(PoolingBlock(2, 1, 0.5, 0.5));//11
+    // sequential->template Add(ConvolutionalBlock(3, 1024));//12
+    // sequential->template Add(ConvolutionalBlock(1, 256, 1, 0));//13
+    // sequential->template Add(ConvolutionalBlock(1, 128, 1, 0));//18
+    // sequential->template Add(UpsampleBlock(2.0f));//19
+    //
+    // MultiLayer<MatType>* layer8= new MultiLayer<MatType>();
+    // layer8->template Add(ConvolutionalBlock(3, 256));//8
+    //
+    // Concat* concatBlock = new Concat(2);
+    // concatBlock->Add(sequential);
+    // concatBlock->Add(layer8);
+    //
+    // small.template Add(concatBlock);//20
+    // small.template Add(ConvolutionalBlock(3, 256));//21
+    // small.template Add(ConvolutionalBlock(1, 255, 1, 0, false, false));//22
+    // small.template Add(YOLOv3Block({0, 1, 2}));//23
+    //
+    // small.Reset();
+    // large.Reset();
   }
 
-  ~YoloV3Tiny() {}
+  ~YoloV3Tiny() { delete large; }
 
   void Predict(const MatType& predictors,
-	       MatType& results,
-	       const size_t batchSize = 128) {
-    small.Predict(predictors, results, batchSize);
-    // large.Predict(predictors, ??, batchSize);//append small object detections with large object detections
+	       MatType& results) {
+    large->Forward(predictors, results);
   }
 
-  //void Train();
-
   void printModel() {
-
     printf("Large object detections:\n");
-    for (size_t i = 0; i < large.Network().size(); i++) {
-      auto layer = large.Network()[i];
-      printLayer(layer, i);
-    }
-    printf("Small object detections:\n");
-    for (size_t i = 0; i < small.Network().size(); i++) {
-      auto layer = small.Network()[i];
+    for (size_t i = 0; i < large->Network().size(); i++) {
+      auto layer = large->Network()[i];
       printLayer(layer, i);
     }
   }
 
 private:
-  MultiLayer<MatType>* PoolingBlock(const size_t kernel, const size_t stride, const double paddingW=0, const double paddingH=0) {
-    MultiLayer<MatType>* poolingBlock = new MultiLayer<MatType>();
-    if (paddingW || paddingH)
-      poolingBlock->template Add<Padding>(std::ceil(paddingW), std::floor(paddingW), std::ceil(paddingH), std::floor(paddingH));
-    poolingBlock->template Add<MaxPooling>(kernel, kernel, stride, stride);
-    return poolingBlock;
-  }
-
-  MultiLayer<MatType>* ConvolutionalBlock(const size_t kernelSize,
-			     const size_t filters,
-			     const size_t stride = 1,
-			     const size_t padding = 1,
-			     const bool batchNorm = true,
-			     const bool activate = true) {
-    MultiLayer<MatType>* convBlock = new MultiLayer<MatType>();
-    convBlock->template Add<Convolution>(filters, kernelSize, kernelSize, stride, stride, padding, padding, "none", !batchNorm);
-    if (batchNorm) {
-      convBlock->template Add<BatchNorm>();
-    }
-    if (activate) {
-      convBlock->template Add<LeakyReLU>(0.1f);
-    }
-    return convBlock;
-  }
-
   MultiLayer<MatType>* UpsampleBlock(const double scaleFactor) {
     MultiLayer<MatType>* upsampleBlock = new MultiLayer<MatType>();
     std::vector<double> scaleFactors = {scaleFactor, scaleFactor};
@@ -149,12 +149,10 @@ private:
     return upsampleBlock;
   }
 
-  Layer<MatType>* YOLOv3Block(const std::vector<size_t> mask) {
-    return new mlpack::YOLOv3Layer<MatType>(mask, anchors);
-  }
+  MultiLayer<MatType>* large = new MultiLayer<MatType>();
+  // MultiLayer<MatType>* small = new MultiLayer<MatType>();
 
-  FFN<YoloV3TinyLoss<MatType>, RandomInitialization> large;
-  FFN<YoloV3TinyLoss<MatType>, RandomInitialization> small;
+  YoloV3TinyLoss<MatType> outputLayer;
 
   size_t inputWidth;
   size_t inputHeight;

--- a/models/yolov3_tiny/yolov3_tiny_layer.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_layer.hpp
@@ -11,12 +11,7 @@ template<typename MatType>
 class YOLOv3Layer : public Layer<MatType>
 {
  public:
-  YOLOv3Layer(std::vector<size_t> mask,
-              std::vector<double> anchors,
-              size_t classes = 80):
-    mask(mask),
-    anchors(anchors),
-    classes(classes)
+  YOLOv3Layer()
   {}
 
   //! Clone the YOLOv3Layer object. This handles polymorphism correctly.
@@ -27,22 +22,16 @@ class YOLOv3Layer : public Layer<MatType>
 
   //! Copy the given YOLOv3Layer layer.
   YOLOv3Layer(const YOLOv3Layer& other) :
-    Layer<MatType>(other),
-    mask(other.mask),
-    anchors(other.anchors)
+    Layer<MatType>(other)
   {}
   //! Take ownership of the given YOLOv3Layer layer.
   YOLOv3Layer(YOLOv3Layer&& other) :
-    Layer<MatType>(std::move(other)),
-    mask(std::move(other.mask)),
-    anchors(std::move(other.anchors))
+    Layer<MatType>(std::move(other))
   {}
   //! Copy the given YOLOv3Layer layer.
   YOLOv3Layer& operator=(const YOLOv3Layer& other) {
     if (&other != this) {
       Layer<MatType>::operator=(other);
-      mask = other.mask;
-      anchors = other.anchors;
     }
     return *this;
   }
@@ -50,8 +39,6 @@ class YOLOv3Layer : public Layer<MatType>
   YOLOv3Layer& operator=(YOLOv3Layer&& other) {
     if (&other != this) {
       Layer<MatType>::operator=(std::move(other));
-      mask = std::move(other.mask);
-      anchors = std::move(other.anchors);
     }
     return *this;
   }
@@ -76,7 +63,7 @@ class YOLOv3Layer : public Layer<MatType>
   }
 
   /**
-   * Backward pass: send weights backwards (the bias does not affect anything).
+   * Backward pass: send weights backwards
    *
    * @param input The input data (x) given to the forward pass.
    * @param output The propagated data (f(x)) resulting from Forward()
@@ -93,17 +80,7 @@ class YOLOv3Layer : public Layer<MatType>
    * Serialize the layer.
    */
   template<typename Archive>
-  void serialize(Archive& ar, const uint32_t /* version */) {
-    ar(CEREAL_NVP(mask));
-    ar(CEREAL_NVP(anchors));
-    ar(CEREAL_NVP(classes));
-  }
-
- private:
-
-  std::vector<size_t> mask;
-  std::vector<double> anchors;
-  size_t classes;
+  void serialize(Archive& ar, const uint32_t /* version */) {}
 };
 
 } // namespace mlpack

--- a/models/yolov3_tiny/yolov3_tiny_layer.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_layer.hpp
@@ -1,35 +1,26 @@
 /**
- * @author Andrew Furey
+ * @file methods/ann/layer/add.hpp
+ * @author Marcus Edel
  *
- * Definition of the YOLO layer for object detection
+ * Definition of the Add class that applies a bias term to the incoming data.
  *
  * mlpack is free software; you may redistribute it and/or modify it under the
  * terms of the 3-clause BSD license.  You should have received a copy of the
  * 3-clause BSD license along with mlpack.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#ifndef YOLO_LAYER_HPP
-#define YOLO_LAYER_HPP
+#ifndef MLPACK_METHODS_ANN_LAYER_ADD_HPP
+#define MLPACK_METHODS_ANN_LAYER_ADD_HPP
 
 #include <mlpack/prereqs.hpp>
-#include <mlpack/methods/ann.hpp>
+#include "mlpack/methods/ann.hpp"
 
 namespace mlpack {
 
-/*
- * Implementation of the yolo layer for object detection. 
- *
- * @tparam MatType Matrix representation to accept as input and use for
- *    computation.
- */
 template<typename MatType>
 class Yolo : public Layer<MatType>
 {
  public:
-  /**
-   * Create the Yolo object.  The output size of the layer will be the same
-   * as the input size.
-   */
   Yolo();
 
   //! Clone the Yolo object. This handles polymorphism correctly.
@@ -48,12 +39,20 @@ class Yolo : public Layer<MatType>
   Yolo& operator=(Yolo&& other);
 
   /**
-   * Forward pass
+   * Forward pass: add the bias to the input.
+   *
+   * @param input Input data used for evaluating the specified function.
+   * @param output Resulting output activation.
    */
   void Forward(const MatType& input, MatType& output);
 
   /**
-   * Backward pass
+   * Backward pass: send weights backwards (the bias does not affect anything).
+   *
+   * @param input The input data (x) given to the forward pass.
+   * @param output The propagated data (f(x)) resulting from Forward()
+   * @param gy The backpropagated error.
+   * @param g The calculated gradient.
    */
   void Backward(const MatType& /* input */,
                 const MatType& /* output */,
@@ -71,17 +70,7 @@ class Yolo : public Layer<MatType>
                 const MatType& error,
                 MatType& gradient);
 
-  //! Return the weights of the network.
-  const MatType& Parameters() const { return weights; }
-  //! Modify the weights of the network.
-  MatType& Parameters() { return weights; }
-
-  //! Compute the output dimensions of the layer, based on the internal values
-  //! of `InputDimensions()`.
   void ComputeOutputDimensions();
-
-  //! Set the weights of the layer to use the given memory.
-  void SetWeights(const MatType& weightsIn);
 
   /**
    * Serialize the layer.
@@ -90,9 +79,8 @@ class Yolo : public Layer<MatType>
   void serialize(Archive& ar, const uint32_t /* version */);
 
  private:
-  //! Locally-stored weight object.
-  MatType weights;
-}; // Yolo class
+};
+
 } // namespace mlpack
 
 #endif

--- a/models/yolov3_tiny/yolov3_tiny_layer.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_layer.hpp
@@ -90,18 +90,6 @@ class YOLOv3Layer : public Layer<MatType>
   }
 
   /**
-   * Calculate the gradient using the output and the input activation.
-   *
-   * @param * (input) The propagated input.
-   * @param error The calculated error.
-   * @param gradient The calculated gradient.
-   */
-  void Gradient(const MatType& /* input */,
-                const MatType& error,
-                MatType& gradient) {
-  }
-
-  /**
    * Serialize the layer.
    */
   template<typename Archive>

--- a/models/yolov3_tiny/yolov3_tiny_layer.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_layer.hpp
@@ -62,7 +62,7 @@ class YOLOv3Layer : public Layer<MatType>
    * @param input Input data used for evaluating the specified function.
    * @param output Resulting output activation.
    */
-  void Forward(const MatType& input, MatType& output) {
+  void Forward(const MatType& input, MatType& output) {//could do with a rewrite
     output = input;
     output.for_each([](arma::mat::elem_type& value) { value = 1.0f/(1.0f * std::exp(-value)); });
   

--- a/models/yolov3_tiny/yolov3_tiny_layer.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_layer.hpp
@@ -77,10 +77,10 @@ class YOLOv3Layer : public Layer<MatType>
       size_t yChannel = xChannel + 1;
       for (size_t i = 0; i < width; i++) {
         for (size_t j = 0; j < height; j++) {
-          output(i * channels * width +  j * channels + widthChannel) = std::exp(input(i * channels * width +  j * channels + widthChannel)) * anchors[mask[n]];
-          output(i * channels * width + j * channels + widthChannel+1) = std::exp(input(i * channels * width + j * channels + widthChannel+1)) * anchors[mask[n]+1];
-          output(i * channels * width +  j * channels +  xChannel) = output(i * channels * width + j * channels +  xChannel) + i;
-          output(i * channels * width +  j * channels + yChannel) = output(i * channels * width + j * channels + yChannel) + j;
+          output(i * channels * width +  j * channels + widthChannel) = (std::exp(input(i * channels * width +  j * channels + widthChannel)) * anchors[mask[n]]) / 416;
+          output(i * channels * width + j * channels + widthChannel+1) = (std::exp(input(i * channels * width + j * channels + widthChannel+1)) * anchors[mask[n]+1]) / 416;
+          output(i * channels * width +  j * channels +  xChannel) = (output(i * channels * width + j * channels +  xChannel) + i) / 13;
+          output(i * channels * width +  j * channels + yChannel) = (output(i * channels * width + j * channels + yChannel) + j) / 13;//TODO: get rid of constants
         }
       }
     }

--- a/models/yolov3_tiny/yolov3_tiny_layer.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_layer.hpp
@@ -1,14 +1,3 @@
-/**
- * @file methods/ann/layer/add.hpp
- * @author Marcus Edel
- *
- * Definition of the Add class that applies a bias term to the incoming data.
- *
- * mlpack is free software; you may redistribute it and/or modify it under the
- * terms of the 3-clause BSD license.  You should have received a copy of the
- * 3-clause BSD license along with mlpack.  If not, see
- * http://www.opensource.org/licenses/BSD-3-Clause for more information.
- */
 #ifndef MLPACK_METHODS_ANN_LAYER_ADD_HPP
 #define MLPACK_METHODS_ANN_LAYER_ADD_HPP
 
@@ -18,25 +7,25 @@
 namespace mlpack {
 
 template<typename MatType>
-class Yolo : public Layer<MatType>
+class YoloLayer : public Layer<MatType>
 {
  public:
-  Yolo();
+  YoloLayer();
 
-  //! Clone the Yolo object. This handles polymorphism correctly.
-  Yolo* Clone() const { return new Yolo(*this); }
+  //! Clone the YoloLayer object. This handles polymorphism correctly.
+  YoloLayer* Clone() const { return new YoloLayer(*this); }
 
   // Virtual destructor.
-  virtual ~Yolo() { }
+  virtual ~YoloLayer() { }
 
-  //! Copy the given Yolo layer.
-  Yolo(const Yolo& other);
-  //! Take ownership of the given Yolo layer.
-  Yolo(Yolo&& other);
-  //! Copy the given Yolo layer.
-  Yolo& operator=(const Yolo& other);
-  //! Take ownership of the given Yolo layer.
-  Yolo& operator=(Yolo&& other);
+  //! Copy the given YoloLayer layer.
+  YoloLayer(const YoloLayer& other);
+  //! Take ownership of the given YoloLayer layer.
+  YoloLayer(YoloLayer&& other);
+  //! Copy the given YoloLayer layer.
+  YoloLayer& operator=(const YoloLayer& other);
+  //! Take ownership of the given YoloLayer layer.
+  YoloLayer& operator=(YoloLayer&& other);
 
   /**
    * Forward pass: add the bias to the input.
@@ -44,7 +33,7 @@ class Yolo : public Layer<MatType>
    * @param input Input data used for evaluating the specified function.
    * @param output Resulting output activation.
    */
-  void Forward(const MatType& input, MatType& output);
+  void Forward(const MatType& input, MatType& output) {}
 
   /**
    * Backward pass: send weights backwards (the bias does not affect anything).
@@ -57,7 +46,7 @@ class Yolo : public Layer<MatType>
   void Backward(const MatType& /* input */,
                 const MatType& /* output */,
                 const MatType& gy,
-                MatType& g);
+                MatType& g) {}
 
   /**
    * Calculate the gradient using the output and the input activation.
@@ -68,15 +57,15 @@ class Yolo : public Layer<MatType>
    */
   void Gradient(const MatType& /* input */,
                 const MatType& error,
-                MatType& gradient);
+                MatType& gradient) {}
 
-  void ComputeOutputDimensions();
+  void ComputeOutputDimensions() {}
 
   /**
    * Serialize the layer.
    */
   template<typename Archive>
-  void serialize(Archive& ar, const uint32_t /* version */);
+  void serialize(Archive& ar, const uint32_t /* version */) {}
 
  private:
 };

--- a/models/yolov3_tiny/yolov3_tiny_layer.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_layer.hpp
@@ -64,7 +64,7 @@ class YOLOv3Layer : public Layer<MatType>
    */
   void Forward(const MatType& input, MatType& output) {
     output = input;
-    output.for_each([](arma::mat::elem_type& value) { value = 1.0f/(1.0f * std::exp(value)); });
+    output.for_each([](arma::mat::elem_type& value) { value = 1.0f/(1.0f * std::exp(-value)); });
   
     size_t channels = this->InputDimensions()[2];
     size_t width = this->InputDimensions()[0];
@@ -77,8 +77,10 @@ class YOLOv3Layer : public Layer<MatType>
       size_t yChannel = xChannel + 1;
       for (size_t i = 0; i < width; i++) {
         for (size_t j = 0; j < height; j++) {
+          //give a number between 0-416
           output(i * channels * width +  j * channels + widthChannel) = std::exp(input(i * channels * width +  j * channels + widthChannel)) * anchors[mask[n]];
-          output(i * channels * width + j * channels + widthChannel+1) = std::exp(input(i * channels * width + j * channels + widthChannel+1)) * anchors[mask[n]+1];
+          output(i * channels * width + j * channels + heightChannel) = std::exp(input(i * channels * width + j * channels + heightChannel)) * anchors[mask[n]+1];
+          //give a number between 0-13
           output(i * channels * width +  j * channels +  xChannel) = output(i * channels * width + j * channels +  xChannel) + i;
           output(i * channels * width +  j * channels + yChannel) = output(i * channels * width + j * channels + yChannel) + j;
         }

--- a/models/yolov3_tiny/yolov3_tiny_layer.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_layer.hpp
@@ -11,7 +11,14 @@ template<typename MatType>
 class YOLOv3Layer : public Layer<MatType>
 {
  public:
-  YOLOv3Layer()
+  YOLOv3Layer(std::vector<std::pair<size_t, size_t>> anchors,
+              size_t width = 416,
+              size_t height = 416,
+              size_t classes = 80) : 
+    anchors(anchors),
+    width(width),
+    height(height),
+    classes(classes)
   {}
 
   //! Clone the YOLOv3Layer object. This handles polymorphism correctly.
@@ -22,16 +29,28 @@ class YOLOv3Layer : public Layer<MatType>
 
   //! Copy the given YOLOv3Layer layer.
   YOLOv3Layer(const YOLOv3Layer& other) :
-    Layer<MatType>(other)
+    Layer<MatType>(other),
+    anchors(other.anchors),
+    width(width),
+    height(height),
+    classes(classes)
   {}
   //! Take ownership of the given YOLOv3Layer layer.
   YOLOv3Layer(YOLOv3Layer&& other) :
-    Layer<MatType>(std::move(other))
+    Layer<MatType>(std::move(other)),
+    anchors(std::move(other.anchors)),
+    width(std::move(other.width)),
+    height(std::move(other.height)),
+    classes(std::move(other.classes))
   {}
   //! Copy the given YOLOv3Layer layer.
   YOLOv3Layer& operator=(const YOLOv3Layer& other) {
     if (&other != this) {
       Layer<MatType>::operator=(other);
+      anchors = other.anchors;
+      width = other.width;
+      height = other.height;
+      classes = other.classes;
     }
     return *this;
   }
@@ -39,6 +58,10 @@ class YOLOv3Layer : public Layer<MatType>
   YOLOv3Layer& operator=(YOLOv3Layer&& other) {
     if (&other != this) {
       Layer<MatType>::operator=(std::move(other));
+      anchors = other.anchors;
+      width = other.width;
+      height = other.height;
+      classes = other.classes;
     }
     return *this;
   }
@@ -55,11 +78,23 @@ class YOLOv3Layer : public Layer<MatType>
     size_t channels = this->InputDimensions()[2];
     size_t batchSize = this->InputDimensions()[3];
 
-    auto f = [](const arma::mat::elem_type& value) { return 1.0f/(1.0f * std::exp(-value));};
+    auto f = [](const arma::mat::elem_type& value) { 
+      return 1.0f/(1.0f * std::exp(-value));
+    };
 
     output = input;
     output.submat(0, 0, width * height * 2 - 1, batchSize - 1).transform(f);//x, y
     output.submat(width * height * 4, 0, output.n_rows - 1, batchSize - 1).transform(f);//obj, probs
+
+    // for (size_t mask = 0; mask < anchors.size(); mask++) {
+    //   size_t anchorWidth = anchors[mask].first;
+    //   size_t anchorHeight = anchors[mask].second;
+    //   
+    //   auto x = [](const arma::mat::elem_type& value) {
+    //     
+    //   };
+    //   
+    // }
   }
 
   /**
@@ -74,6 +109,11 @@ class YOLOv3Layer : public Layer<MatType>
                 const MatType& /* output */,
                 const MatType& gy,
                 MatType& g) {
+
+    // auto f = [](const arma::mat::elem_type& value) { return 1.0f/(1.0f * std::exp(-value));};
+    // auto df = [=](const arma::mat::elem_type& value) {
+    //   return f(value) * (1 - f(value));
+    // };
   }
 
   /**
@@ -81,6 +121,22 @@ class YOLOv3Layer : public Layer<MatType>
    */
   template<typename Archive>
   void serialize(Archive& ar, const uint32_t /* version */) {}
+
+private:
+  size_t outputIndex(size_t mask, size_t cell, size_t offset, size_t width, size_t height, size_t classes) {
+    assert(mask >= 0 && mask < 3);//3 should be const?
+    assert(cell >= 0 && cell < width * height);
+    assert(offset >= 0 && offset < classes);
+    return mask * width * height * (4 + 1 + classes) + offset * width * height + cell;
+  }
+  // Anchors are (width,height) pairs
+  std::vector<std::pair<size_t, size_t>> anchors;
+  // Width of input image
+  size_t width;
+  // Height of input image
+  size_t height;
+  // Number of classes
+  size_t classes;
 };
 
 } // namespace mlpack

--- a/models/yolov3_tiny/yolov3_tiny_layer.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_layer.hpp
@@ -79,22 +79,15 @@ class YOLOv3Layer : public Layer<MatType>
     size_t batchSize = this->InputDimensions()[3];
 
     auto f = [](const arma::mat::elem_type& value) { 
-      return 1.0f/(1.0f * std::exp(-value));
+      return 1.0f/(1.0f + std::exp(-value));
     };
 
     output = input;
     output.submat(0, 0, width * height * 2 - 1, batchSize - 1).transform(f);//x, y
     output.submat(width * height * 4, 0, output.n_rows - 1, batchSize - 1).transform(f);//obj, probs
-
-    // for (size_t mask = 0; mask < anchors.size(); mask++) {
-    //   size_t anchorWidth = anchors[mask].first;
-    //   size_t anchorHeight = anchors[mask].second;
-    //   
-    //   auto x = [](const arma::mat::elem_type& value) {
-    //     
-    //   };
-    //   
-    // }
+    // TODO: transform w and h.
+    // w = anchor_box_w * exp(w)
+    // h = anchor_box_h * exp(h)
   }
 
   /**
@@ -110,10 +103,6 @@ class YOLOv3Layer : public Layer<MatType>
                 const MatType& gy,
                 MatType& g) {
 
-    // auto f = [](const arma::mat::elem_type& value) { return 1.0f/(1.0f * std::exp(-value));};
-    // auto df = [=](const arma::mat::elem_type& value) {
-    //   return f(value) * (1 - f(value));
-    // };
   }
 
   /**

--- a/models/yolov3_tiny/yolov3_tiny_layer.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_layer.hpp
@@ -1,39 +1,90 @@
-#ifndef MLPACK_METHODS_ANN_LAYER_ADD_HPP
-#define MLPACK_METHODS_ANN_LAYER_ADD_HPP
+#ifndef YOLOV3_LAYER_HPP
+#define YOLOV3_LAYER_HPP
 
+#include <cmath>
 #include <mlpack/prereqs.hpp>
 #include "mlpack/methods/ann.hpp"
 
 namespace mlpack {
 
 template<typename MatType>
-class YoloLayer : public Layer<MatType>
+class YOLOv3Layer : public Layer<MatType>
 {
  public:
-  YoloLayer();
+  YOLOv3Layer(std::vector<size_t> mask,
+              std::vector<double> anchors,
+              size_t classes = 80):
+    mask(mask),
+    anchors(anchors),
+    classes(classes)
+  {}
 
-  //! Clone the YoloLayer object. This handles polymorphism correctly.
-  YoloLayer* Clone() const { return new YoloLayer(*this); }
+  //! Clone the YOLOv3Layer object. This handles polymorphism correctly.
+  YOLOv3Layer* Clone() const { return new YOLOv3Layer(*this); }
 
   // Virtual destructor.
-  virtual ~YoloLayer() { }
+  virtual ~YOLOv3Layer() { }
 
-  //! Copy the given YoloLayer layer.
-  YoloLayer(const YoloLayer& other);
-  //! Take ownership of the given YoloLayer layer.
-  YoloLayer(YoloLayer&& other);
-  //! Copy the given YoloLayer layer.
-  YoloLayer& operator=(const YoloLayer& other);
-  //! Take ownership of the given YoloLayer layer.
-  YoloLayer& operator=(YoloLayer&& other);
+  //! Copy the given YOLOv3Layer layer.
+  YOLOv3Layer(const YOLOv3Layer& other) :
+    Layer<MatType>(other),
+    mask(other.mask),
+    anchors(other.anchors)
+  {}
+  //! Take ownership of the given YOLOv3Layer layer.
+  YOLOv3Layer(YOLOv3Layer&& other) :
+    Layer<MatType>(std::move(other)),
+    mask(std::move(other.mask)),
+    anchors(std::move(other.anchors))
+  {}
+  //! Copy the given YOLOv3Layer layer.
+  YOLOv3Layer& operator=(const YOLOv3Layer& other) {
+    if (&other != this) {
+      Layer<MatType>::operator=(other);
+      mask = other.mask;
+      anchors = other.anchors;
+    }
+    return *this;
+  }
+  //! Take ownership of the given YOLOv3Layer layer.
+  YOLOv3Layer& operator=(YOLOv3Layer&& other) {
+    if (&other != this) {
+      Layer<MatType>::operator=(std::move(other));
+      mask = std::move(other.mask);
+      anchors = std::move(other.anchors);
+    }
+    return *this;
+  }
 
   /**
-   * Forward pass: add the bias to the input.
+   * Forward pass: squeeze (x, y), objectness and probabilities between 0 and 1
    *
    * @param input Input data used for evaluating the specified function.
    * @param output Resulting output activation.
    */
-  void Forward(const MatType& input, MatType& output) {}
+  void Forward(const MatType& input, MatType& output) {
+    output = input;
+    output.for_each([](arma::mat::elem_type& value) { value = 1.0f/(1.0f * std::exp(value)); });
+  
+    size_t channels = this->InputDimensions()[2];
+    size_t width = this->InputDimensions()[0];
+    size_t height = this->InputDimensions()[1];
+
+    for (size_t n = 0; n < mask.size(); n++) {
+      size_t widthChannel = 2 + (channels / mask.size()) * n;
+      size_t heightChannel = widthChannel + 1;
+      size_t xChannel = (channels / mask.size()) * n;
+      size_t yChannel = xChannel + 1;
+      for (size_t i = 0; i < width; i++) {
+        for (size_t j = 0; j < height; j++) {
+          output(i * channels * width +  j * channels + widthChannel) = std::exp(input(i * channels * width +  j * channels + widthChannel)) * anchors[mask[n]];
+          output(i * channels * width + j * channels + widthChannel+1) = std::exp(input(i * channels * width + j * channels + widthChannel+1)) * anchors[mask[n]+1];
+          output(i * channels * width +  j * channels +  xChannel) = output(i * channels * width + j * channels +  xChannel) + i;
+          output(i * channels * width +  j * channels + yChannel) = output(i * channels * width + j * channels + yChannel) + j;
+        }
+      }
+    }
+  }
 
   /**
    * Backward pass: send weights backwards (the bias does not affect anything).
@@ -59,15 +110,21 @@ class YoloLayer : public Layer<MatType>
                 const MatType& error,
                 MatType& gradient) {}
 
-  void ComputeOutputDimensions() {}
-
   /**
    * Serialize the layer.
    */
   template<typename Archive>
-  void serialize(Archive& ar, const uint32_t /* version */) {}
+  void serialize(Archive& ar, const uint32_t /* version */) {
+    ar(CEREAL_NVP(mask));
+    ar(CEREAL_NVP(anchors));
+    ar(CEREAL_NVP(classes));
+  }
 
  private:
+
+  std::vector<size_t> mask;
+  std::vector<double> anchors;
+  size_t classes;
 };
 
 } // namespace mlpack

--- a/models/yolov3_tiny/yolov3_tiny_loss.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_loss.hpp
@@ -9,17 +9,22 @@ template<typename MatType = arma::mat>
 class YoloV3TinyLoss
 {
  public:
-  YoloV3TinyLoss();
+  YoloV3TinyLoss() {}
+
+  // L(YOLO) = a1 * L(confidence) + a2 * L(localization) + a3 * L(classification)
+  // L(confidence) = binary cross entropy
+  // L(localization) = rmse
+  // L(classification) = multi class cross entropy
 
   typename MatType::elem_type Forward(const MatType& prediction,
-                                      const MatType& target);
+                                      const MatType& target) {}
 
   void Backward(const MatType& prediction,
                 const MatType& target,
-                MatType& loss);
+                MatType& loss) {}
 
   template<typename Archive>
-  void serialize(Archive& ar, const uint32_t /* version */);
+  void serialize(Archive& ar, const uint32_t /* version */) {}
 
  private:
 };

--- a/models/yolov3_tiny/yolov3_tiny_loss.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_loss.hpp
@@ -9,24 +9,74 @@ template<typename MatType = arma::mat>
 class YoloV3TinyLoss
 {
  public:
-  YoloV3TinyLoss() {}
+  YoloV3TinyLoss(size_t width,
+                 size_t height,
+                 double confidence = 0.5, 
+                 double localizaiton = 0.9, 
+                 double classifcation = 0.6,
+                 size_t classes = 80) :
+                                    confidence(confidence),
+                                    localization(localization),
+                                    classification(classification),
+                                    width(width),
+                                    height(height),
+                                    classes(classes)
+                                    {}
 
   // L(YOLO) = a1 * L(confidence) + a2 * L(localization) + a3 * L(classification)
   // L(confidence) = binary cross entropy
-  // L(localization) = rmse
+  // L(localization) = mse
   // L(classification) = multi class cross entropy
 
   typename MatType::elem_type Forward(const MatType& prediction,
-                                      const MatType& target) {}
+                                      const MatType& target) {
+    
+    typename MatType::elem_type localizationLoss = 0;
+    typename MatType::elem_type classificationLoss = 0;
+    typename MatType::elem_type confidenceLoss = 0;
+
+    MatType xyPred = prediction.submat(0, prediction.n_cols - 1, width * height * 2 - 1, prediction.n_cols - 1);
+    MatType xyTarg = target.submat(0, prediction.n_cols - 1, width * height * 2 - 1, target.n_cols - 1);
+
+    MatType whPred = prediction.submat(width * height * 2, prediction.n_cols - 1, width * height * 4 - 1, prediction.n_cols - 1);
+    MatType whTarg = target.submat(width * height * 2, prediction.n_cols - 1, width * height * 4 - 1, target.n_cols - 1);
+    localizationLoss = localizationLossFn.Forward(xyPred, xyTarg) + localizationLossFn.Forward(whPred, whTarg);
+
+    MatType confidencePred = prediction.submat(width * height * 4, prediction.n_cols - 1, width * height * 5 - 1, prediction.n_cols);
+    MatType confidenceTarg = target.submat(width * height * 4, target.n_cols - 1, width * height * 5 - 1, target.n_cols - 1);
+    confidenceLoss = confidenceLossFn.Forward(confidencePred, confidenceTarg);
+
+    MatType classificationPred = prediction.submat(width * height * 5, prediction.n_cols - 1, prediction.n_rows - 1, prediction.n_cols);
+    MatType classificationTarg = target.submat(width * height * 5, target.n_cols - 1, target.n_rows - 1, target.n_cols - 1);
+    classificationLoss = classificationLossFn(classificationPred, classificationTarg);
+
+    typename MatType::elem_type loss = localization * localizationLoss + 
+                                       classification * classificationLoss +
+                                       confidence * confidenceLoss;
+    return loss;
+  }
 
   void Backward(const MatType& prediction,
                 const MatType& target,
-                MatType& loss) {}
+                MatType& loss) {
+
+  }
 
   template<typename Archive>
   void serialize(Archive& ar, const uint32_t /* version */) {}
 
  private:
+  double classification;
+  double localization;
+  double confidence;
+
+  BCELossType<> confidenceLossFn;
+  MeanSquaredErrorType<> localizationLossFn;
+  MultiLabelSoftMarginLossType<> classificationLossFn;
+
+  size_t width;
+  size_t height;
+  size_t classes;
 };
 
 

--- a/models/yolov3_tiny/yolov3_tiny_loss.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_loss.hpp
@@ -9,24 +9,19 @@ template<typename MatType = arma::mat>
 class YoloV3TinyLoss
 {
  public:
-  YoloV3TinyLoss(size_t width,
-                 size_t height,
+  YoloV3TinyLoss(size_t width = 13,
+                 size_t height = 13,
                  double confidence = 0.5, 
                  double localizaiton = 0.9, 
                  double classifcation = 0.6,
                  size_t classes = 80) :
-                                    confidence(confidence),
-                                    localization(localization),
-                                    classification(classification),
-                                    width(width),
-                                    height(height),
-                                    classes(classes)
+    width(width),
+    height(height),
+    confidence(confidence),
+    localization(localization),
+    classification(classification),
+    classes(classes)
                                     {}
-
-  // L(YOLO) = a1 * L(confidence) + a2 * L(localization) + a3 * L(classification)
-  // L(confidence) = binary cross entropy
-  // L(localization) = mse
-  // L(classification) = multi class cross entropy
 
   typename MatType::elem_type Forward(const MatType& prediction,
                                       const MatType& target) {
@@ -63,7 +58,11 @@ class YoloV3TinyLoss
   }
 
   template<typename Archive>
-  void serialize(Archive& ar, const uint32_t /* version */) {}
+  void serialize(Archive& ar, const uint32_t /* version */) {
+    ar(CEREAL_NVP(width));
+    ar(CEREAL_NVP(height));
+    ar(CEREAL_NVP(classes));
+  }
 
  private:
   double classification;
@@ -74,9 +73,9 @@ class YoloV3TinyLoss
   MeanSquaredErrorType<> localizationLossFn;
   MultiLabelSoftMarginLossType<> classificationLossFn;
 
+  size_t classes;
   size_t width;
   size_t height;
-  size_t classes;
 };
 
 

--- a/models/yolov3_tiny/yolov3_tiny_loss.hpp
+++ b/models/yolov3_tiny/yolov3_tiny_loss.hpp
@@ -1,0 +1,30 @@
+#ifndef YOLO_LOSS_HPP
+#define YOLO_LOSS_HPP
+
+#include <mlpack/prereqs.hpp>
+
+namespace mlpack {
+
+template<typename MatType = arma::mat>
+class YoloV3TinyLoss
+{
+ public:
+  YoloV3TinyLoss();
+
+  typename MatType::elem_type Forward(const MatType& prediction,
+                                      const MatType& target);
+
+  void Backward(const MatType& prediction,
+                const MatType& target,
+                MatType& loss);
+
+  template<typename Archive>
+  void serialize(Archive& ar, const uint32_t /* version */);
+
+ private:
+};
+
+
+} // namespace mlpack
+
+#endif


### PR DESCRIPTION
Implementation of the yolov3-tiny architecture for Google Summer of Code. 
- [x] YOLO forward pass
- [ ] YOLO backward pass
- [x] YOLO Loss forward pass
- [ ] YOLO loss backward pass
- [x] Implement YOLOv3-tiny
- [ ] Documentation

The mlpack model is used [here](https://github.com/andrewfurey21/yolov3-tiny/) which has a bunch of preprocessing and post processing steps too needed for inference.